### PR TITLE
pom refactor

### DIFF
--- a/jzy3d-api/pom.xml
+++ b/jzy3d-api/pom.xml
@@ -80,6 +80,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>${version.build.helper.mvn}</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -102,6 +103,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${version.mvn.surefire}</version>
 				<configuration>
 					<excludes>
 						<exclude>org/jzy3d/junit/ChartTest.java</exclude>
@@ -111,6 +113,7 @@
 
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
+				<version>${version.mvn.jar}</version>
 				<executions>
 					<execution>
 						<id>maths-io-jar</id>
@@ -140,6 +143,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>build-helper-maven-plugin</artifactId>
+					<version>${version.build.helper.mvn}</version>
 					<executions>
 						<execution>
 							<phase>generate-sources</phase>
@@ -161,7 +165,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.0</version><!--$NO-MVN-MAN-VER$ -->
+					<version>${version.mvn.compiler}</version>
 					<configuration>
 						<source>1.7</source>
 						<target>1.7</target>
@@ -171,6 +175,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
+					<version>${version.mvn.source}</version>
 					<executions>
 						<execution>
 							<id>attach-sources</id>

--- a/jzy3d-api/src/api/org/jzy3d/plot3d/rendering/ordering/BarycentreOrderingStrategy.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/rendering/ordering/BarycentreOrderingStrategy.java
@@ -30,7 +30,7 @@ public class BarycentreOrderingStrategy extends AbstractOrderingStrategy{
      */
 	@Override
     public int compare(AbstractDrawable d1, AbstractDrawable d2) {
-		if(d1.equals(d2))
+		if(d1.equals(d2) || d1.getBarycentre().equals(d2.getBarycentre()))
 			return 0;
 		return comparison(score(d1), score(d2));
 	}

--- a/jzy3d-javafx/pom.xml
+++ b/jzy3d-javafx/pom.xml
@@ -40,7 +40,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.0</version>
+					<version>${version.mvn.compiler}</version>
 					<configuration>
 						<source>1.8</source>
 						<target>1.8</target>
@@ -49,6 +49,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${version.mvn.surefire}</version>
 					<configuration>
 						<!--<excludes> <exclude>org/jzy3d/junit/ChartTest.java</exclude> </excludes> -->
 					</configuration>
@@ -57,6 +58,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
+					<version>${version.mvn.source}</version>
 					<executions>
 						<execution>
 							<id>attach-sources</id>

--- a/jzy3d-jdt-core/pom.xml
+++ b/jzy3d-jdt-core/pom.xml
@@ -53,7 +53,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
+				<version>${version.mvn.compiler}</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>
@@ -63,6 +63,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
+				<version>${version.mvn.source}</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/jzy3d-swt/pom.xml
+++ b/jzy3d-swt/pom.xml
@@ -33,15 +33,10 @@
 		<dependency>
 			<groupId>org.eclipse.swt</groupId>
 			<artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
-			<version>4.2.1</version>
+			<version>${version.libs.swt}</version>
 		</dependency>
 		<!--<dependency> <groupId>org.eclipse.swt.win32.win32</groupId> <artifactId>x86</artifactId>
-			<version>4.2.1</version> </dependency> -->
-		<dependency>
-			<groupId>org.eclipse.swt</groupId>
-			<artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
-			<version>4.2.1</version>
-		</dependency>
+			<version>${version.libs.swt}</version> </dependency> -->
 
 		<dependency>
 			<groupId>junit</groupId>
@@ -60,6 +55,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>build-helper-maven-plugin</artifactId>
+					<version>${version.build.helper.mvn}</version>
 					<executions>
 						<execution>
 							<phase>generate-sources</phase>
@@ -77,7 +73,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.0</version>
+					<version>${version.mvn.compiler}</version>
 					<configuration>
 						<source>1.6</source>
 						<target>1.6</target>
@@ -86,6 +82,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${version.mvn.surefire}</version>
 					<configuration>
 						<!--<excludes> <exclude>org/jzy3d/junit/ChartTest.java</exclude> </excludes> -->
 					</configuration>
@@ -94,6 +91,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
+					<version>${version.mvn.source}</version>
 					<executions>
 						<execution>
 							<id>attach-sources</id>

--- a/jzy3d-tutorials/pom.xml
+++ b/jzy3d-tutorials/pom.xml
@@ -6,6 +6,12 @@
 	<artifactId>jzy3d-tutorials</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 
+	<parent>
+		<groupId>org.jzy3d</groupId>
+		<artifactId>jzy3d-master</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
 	<name>Jzy3d Tutorials</name>
 
 	<!--To retrieve Jzy3d dependencies -->
@@ -62,7 +68,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
+				<version>${version.mvn.compiler}</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>
@@ -79,6 +85,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${version.mvn.surefire}</version>
 				<configuration>
 				</configuration>
 			</plugin>
@@ -86,6 +93,7 @@
 			<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
+					<version>${version.mvn.source}</version>
 					<executions>
 						<execution>
 							<id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,15 @@
 		<version.java.source>1.6</version.java.source>
 		<version.java.target>1.6</version.java.target>
 		<version.mvn.compiler>3.0</version.mvn.compiler>
+		<version.mvn.jar>3.0.0</version.mvn.jar>
+		<version.mvn.source>3.0.0</version.mvn.source>
 		<version.mvn.ftp>1.0-beta-6</version.mvn.ftp>
 		<version.mvn.deploy>2.4</version.mvn.deploy>
 		<version.mvn.javadoc>2.9.1</version.mvn.javadoc>
 		<version.libs.junit>4.10</version.libs.junit>
-		<version.libs.swt>4.2.1</version.libs.swt>
+		<version.libs.swt>4.3</version.libs.swt>
+		<version.build.helper.mvn>1.10</version.build.helper.mvn>
+		<version.mvn.surefire>2.19.1</version.mvn.surefire>
 	</properties>
 
 	<distributionManagement>


### PR DESCRIPTION
I edited the pom files to remove the Maven warning during the compilation.
I updated the plugin org.eclipse.swt.gtk.linux.x86_64 from version 4.2.1 to 4.3 because the 4.2.1 is not present on Maven Central
I added a version number to all plugings
