### PR TITLE
FIX TimSort IllegalArgumentException(Comparison method violates its general contract)

### DIFF
--- a/jzy3d-api/src/api/org/jzy3d/plot3d/rendering/ordering/BarycentreOrderingStrategy.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/rendering/ordering/BarycentreOrderingStrategy.java
@@ -28,12 +28,12 @@ public class BarycentreOrderingStrategy extends AbstractOrderingStrategy{
      * transitive: ((compare(x, y)>0) && (compare(y, z)>0)) implies compare(x, z)>0    true if all Drawables and the Camera don't change position!
      * consistency?: compare(x, y)==0  implies that sgn(compare(x, z))==sgn(compare(y, z))
      */
-	@Override
+    @Override
     public int compare(AbstractDrawable d1, AbstractDrawable d2) {
-		if(d1.equals(d2))
-			return 0;
-		return comparison(score(d1), score(d2));
-	}
+        if(d1.equals(d2) || d1.getBarycentre().equals(d2.getBarycentre()))
+            return 0;
+        return comparison(score(d1), score(d2));
+    }
 	
     @Override
     public double score(AbstractDrawable d) {


### PR DESCRIPTION
When I have many points on my chart I have an IllegalArgumentException during Sort.
I have solved with this simple modification.
I think that there a problem on sorting when there are  many objects with the same barycenter.

`Caused by: java.lang.IllegalArgumentException: Comparison method violates its general contract!
	at java.util.TimSort.mergeLo(TimSort.java:777)
	at java.util.TimSort.mergeAt(TimSort.java:514)
	at java.util.TimSort.mergeCollapse(TimSort.java:439)
	at java.util.TimSort.sort(TimSort.java:245)
	at java.util.Arrays.sort(Arrays.java:1512)
	at java.util.ArrayList.sort(ArrayList.java:1454)
	at java.util.Collections.sort(Collections.java:175)
	at org.jzy3d.plot3d.rendering.ordering.AbstractOrderingStrategy.sort(AbstractOrderingStrategy.java:38)
	at org.jzy3d.plot3d.rendering.scene.Graph.drawDecomposition(Graph.java:208)
	at org.jzy3d.plot3d.rendering.scene.Graph.draw(Graph.java:184)
	at org.jzy3d.plot3d.rendering.scene.Graph.draw(Graph.java:174)
	at org.jzy3d.plot3d.rendering.view.View.renderSceneGraph(View.java:1022)
	at org.jzy3d.plot3d.rendering.view.View.renderSceneGraph(View.java:1009)
	at org.jzy3d.plot3d.rendering.view.View.renderScene(View.java:858)
	at org.jzy3d.plot3d.rendering.view.layout.ColorbarViewportLayout.render(ColorbarViewportLayout.java:56)
	at org.jzy3d.chart.ChartView.render(ChartView.java:47)
	at org.jzy3d.plot3d.rendering.view.Renderer3d.reshape(Renderer3d.java:107)
	at jogamp.opengl.GLDrawableHelper.init(GLDrawableHelper.java:646)
	at jogamp.opengl.GLDrawableHelper.init(GLDrawableHelper.java:667)
	at jogamp.opengl.GLAutoDrawableBase$1.run(GLAutoDrawableBase.java:431)
	at jogamp.opengl.GLDrawableHelper.invokeGLImpl(GLDrawableHelper.java:1291)
	... 101 more`