### PR TITLE
fix BarycentreOrderingStrategy for pickableObject

### DIFF
--- a/jzy3d-api/src/api/org/jzy3d/plot3d/rendering/ordering/BarycentreOrderingStrategy.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/rendering/ordering/BarycentreOrderingStrategy.java
@@ -30,7 +30,7 @@ public class BarycentreOrderingStrategy extends AbstractOrderingStrategy{
      */
 	@Override
     public int compare(AbstractDrawable d1, AbstractDrawable d2) {
-		if(d1.equals(d2))
+		if(d1 == d2)
 			return 0;
 		return comparison(score(d1), score(d2));
 	}


### PR DESCRIPTION
PickableTexture and PickableObkect redefine equals method. It return true if true if pickableObjects have the same ID or the ID is not initialized.
If you have many pickableObject with same ID, you have a problem when plot the points and obtain the error: TimSort IllegalArgumentException(Comparison method violates its general contract).

In my opinion to solve the problem you can replace equal method with generic object equals method.

The error stack-trace:
`Caused by: java.lang.IllegalArgumentException: Comparison method violates its general contract! at java.util.TimSort.mergeLo(TimSort.java:777) at java.util.TimSort.mergeAt(TimSort.java:514) at java.util.TimSort.mergeCollapse(TimSort.java:439) at java.util.TimSort.sort(TimSort.java:245) at java.util.Arrays.sort(Arrays.java:1512) at java.util.ArrayList.sort(ArrayList.java:1454) at java.util.Collections.sort(Collections.java:175) at org.jzy3d.plot3d.rendering.ordering.AbstractOrderingStrategy.sort(AbstractOrderingStrategy.java:38) at org.jzy3d.plot3d.rendering.scene.Graph.drawDecomposition(Graph.java:208) at org.jzy3d.plot3d.rendering.scene.Graph.draw(Graph.java:184) at org.jzy3d.plot3d.rendering.scene.Graph.draw(Graph.java:174) at org.jzy3d.plot3d.rendering.view.View.renderSceneGraph(View.java:1022) at org.jzy3d.plot3d.rendering.view.View.renderSceneGraph(View.java:1009) at org.jzy3d.plot3d.rendering.view.View.renderScene(View.java:858) at org.jzy3d.plot3d.rendering.view.layout.ColorbarViewportLayout.render(ColorbarViewportLayout.java:56) at org.jzy3d.chart.ChartView.render(ChartView.java:47) at org.jzy3d.plot3d.rendering.view.Renderer3d.reshape(Renderer3d.java:107) at jogamp.opengl.GLDrawableHelper.init(GLDrawableHelper.java:646) at jogamp.opengl.GLDrawableHelper.init(GLDrawableHelper.java:667) at jogamp.opengl.GLAutoDrawableBase$1.run(GLAutoDrawableBase.java:431) at jogamp.opengl.GLDrawableHelper.invokeGLImpl(GLDrawableHelper.java:1291) ... 101 more`
