### PR TITLE
Update pom.xml (eclipse SWT for Maven)

### DIFF
--- a/jzy3d-swt/pom.xml
+++ b/jzy3d-swt/pom.xml
@@ -20,7 +20,7 @@
 	<repositories>
 		<repository>
 			<id>swt-repo</id>
-			<url>https://swt-repo.googlecode.com/svn/repo/</url>
+			<url>http://maven-eclipse.github.io/maven</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
updated link from https://swt-repo.googlecode.com/svn/repo/
to http://maven-eclipse.github.io/maven