### PR TITLE
Fixed hardcoded reference to old JOGL packages

### DIFF
--- a/jzy3d-api/src/api/org/jzy3d/plot3d/rendering/view/Renderer3d.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/rendering/view/Renderer3d.java
@@ -62,9 +62,9 @@ public class Renderer3d implements GLEventListener {
     public void init(GLAutoDrawable canvas) {
         if (canvas != null && canvas.getGL() != null && canvas.getGL().getGL2() != null && view != null) {
             if (debugGL)
-                canvas.getGL().getContext().setGL(GLPipelineFactory.create("javax.media.opengl.Debug", null, canvas.getGL(), null));
+                canvas.getGL().getContext().setGL(GLPipelineFactory.create("com.jogamp.opengl.Debug", null, canvas.getGL(), null));
             if (traceGL)
-                canvas.getGL().getContext().setGL(GLPipelineFactory.create("javax.media.opengl.Trace", null, canvas.getGL(), new Object[] { System.err }));
+                canvas.getGL().getContext().setGL(GLPipelineFactory.create("com.jogamp.opengl.Trace", null, canvas.getGL(), new Object[] { System.err }));
 
             view.init(canvas.getGL());
         }


### PR DESCRIPTION
Almost all the references to JOGL's old "javax.media.opengl" were removed by [this commit](https://github.com/jzy3d/jzy3d-api/commit/6ea7d24be7b372a3cbe1aba6a7092a7a6cf82b2f) but these two string literals in `org.jzy3d.plot3d.rendering.view.Renderer3d` were overlooked, causing a `NoClassDefFoundError` when a `Renderer3d` is created with `traceGL` or `debugGL` set to `true`.