### PR TITLE
Swt newt

### DIFF
--- a/jzy3d-api/src/api/org/jzy3d/chart/factories/IChartComponentFactory.java
+++ b/jzy3d-api/src/api/org/jzy3d/chart/factories/IChartComponentFactory.java
@@ -62,7 +62,7 @@ public interface IChartComponentFactory {
     public IChartComponentFactory getFactory();
     
     public static enum Toolkit {
-        awt, swing, newt, offscreen, swt
+        awt, swing, newt, offscreen, swt_newt
     }
 
 }

--- a/jzy3d-api/src/api/org/jzy3d/chart/factories/IChartComponentFactory.java
+++ b/jzy3d-api/src/api/org/jzy3d/chart/factories/IChartComponentFactory.java
@@ -62,7 +62,7 @@ public interface IChartComponentFactory {
     public IChartComponentFactory getFactory();
     
     public static enum Toolkit {
-        awt, swing, newt, offscreen
+        awt, swing, newt, offscreen, swt
     }
 
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTBridgeDemo.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTBridgeDemo.java
@@ -1,0 +1,67 @@
+package org.jzy3d.analysis;
+
+import java.awt.Component;
+
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.jzy3d.bridge.swt.Bridge;
+import org.jzy3d.chart.Chart;
+import org.jzy3d.chart.Settings;
+import org.jzy3d.chart.factories.AWTChartComponentFactory;
+import org.jzy3d.colors.Color;
+import org.jzy3d.colors.ColorMapper;
+import org.jzy3d.colors.colormaps.ColorMapRainbow;
+import org.jzy3d.maths.Range;
+import org.jzy3d.plot3d.builder.Builder;
+import org.jzy3d.plot3d.builder.Mapper;
+import org.jzy3d.plot3d.builder.concrete.OrthonormalGrid;
+import org.jzy3d.plot3d.primitives.Shape;
+import org.jzy3d.plot3d.rendering.canvas.Quality;
+
+public class SWTBridgeDemo {
+
+	public static void main(String[] args) {
+		Mapper mapper = new Mapper() {
+            @Override
+            public double f(double x, double y) {
+                return x * Math.sin(x * y);
+            }
+        };
+
+        // Define range and precision for the function to plot
+        Range range = new Range(-3, 3);
+        int steps = 80;
+
+        // Create the object to represent the function over the given range.
+        final Shape surface = Builder.buildOrthonormal(new OrthonormalGrid(range, steps, range, steps), mapper);
+        surface.setColorMapper(new ColorMapper(new ColorMapRainbow(), surface.getBounds().getZmin(), surface.getBounds().getZmax(), new Color(1, 1, 1, .5f)));
+        surface.setFaceDisplayed(true);
+        surface.setWireframeDisplayed(false);
+
+        // Create a chart
+        Chart chart = AWTChartComponentFactory.chart(Quality.Advanced, "awt");
+        chart.getScene().getGraph().add(surface);
+        
+        Settings.getInstance().setHardwareAccelerated(true);
+
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setLayout(new FillLayout());
+		Bridge.adapt(shell, (Component) chart.getCanvas());
+
+		shell.setText("name");
+		shell.setSize(800, 600);
+		shell.open();
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+		display.dispose();
+
+	}
+	
+	
+
+}

--- a/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTDemo.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTDemo.java
@@ -1,0 +1,73 @@
+package org.jzy3d.analysis;
+
+import java.awt.Component;
+
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.jzy3d.bridge.swt.Bridge;
+import org.jzy3d.chart.Chart;
+import org.jzy3d.chart.ChartLauncher;
+import org.jzy3d.chart.Settings;
+import org.jzy3d.chart.factories.AWTChartComponentFactory;
+import org.jzy3d.chart.swt.SWTChartComponentFactory;
+import org.jzy3d.colors.Color;
+import org.jzy3d.colors.ColorMapper;
+import org.jzy3d.colors.colormaps.ColorMapRainbow;
+import org.jzy3d.maths.Range;
+import org.jzy3d.plot3d.builder.Builder;
+import org.jzy3d.plot3d.builder.Mapper;
+import org.jzy3d.plot3d.builder.concrete.OrthonormalGrid;
+import org.jzy3d.plot3d.primitives.Shape;
+import org.jzy3d.plot3d.rendering.canvas.Quality;
+
+public class SWTDemo {
+
+	public static void main(String[] args) {
+		Mapper mapper = new Mapper() {
+            @Override
+            public double f(double x, double y) {
+                return x * Math.sin(x * y);
+            }
+        };
+
+        // Define range and precision for the function to plot
+        Range range = new Range(-3, 3);
+        int steps = 80;
+
+        // Create the object to represent the function over the given range.
+        final Shape surface = Builder.buildOrthonormal(new OrthonormalGrid(range, steps, range, steps), mapper);
+        surface.setColorMapper(new ColorMapper(new ColorMapRainbow(), surface.getBounds().getZmin(), surface.getBounds().getZmax(), new Color(1, 1, 1, .5f)));
+        surface.setFaceDisplayed(true);
+        surface.setWireframeDisplayed(false);
+
+        // Create a chart
+        
+        
+        Settings.getInstance().setHardwareAccelerated(true);
+
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setLayout(new FillLayout());
+//		Bridge.adapt(shell, (Component) chart.getCanvas());
+		
+		Chart chart = SWTChartComponentFactory.chart(shell);
+        chart.getScene().getGraph().add(surface);
+        
+        ChartLauncher.openChart(chart);
+
+		shell.setText("name");
+		shell.setSize(800, 600);
+		shell.open();
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+		display.dispose();
+
+	}
+	
+	
+
+}

--- a/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTDemo.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTDemo.java
@@ -1,15 +1,11 @@
 package org.jzy3d.analysis;
 
-import java.awt.Component;
-
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.jzy3d.bridge.swt.Bridge;
 import org.jzy3d.chart.Chart;
 import org.jzy3d.chart.ChartLauncher;
 import org.jzy3d.chart.Settings;
-import org.jzy3d.chart.factories.AWTChartComponentFactory;
 import org.jzy3d.chart.swt.SWTChartComponentFactory;
 import org.jzy3d.colors.Color;
 import org.jzy3d.colors.ColorMapper;
@@ -19,7 +15,6 @@ import org.jzy3d.plot3d.builder.Builder;
 import org.jzy3d.plot3d.builder.Mapper;
 import org.jzy3d.plot3d.builder.concrete.OrthonormalGrid;
 import org.jzy3d.plot3d.primitives.Shape;
-import org.jzy3d.plot3d.rendering.canvas.Quality;
 
 public class SWTDemo {
 

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
@@ -1,13 +1,12 @@
 package org.jzy3d.chart.swt;
 
-import java.awt.BorderLayout;
-import java.awt.Panel;
 import java.io.File;
 import java.io.IOException;
 
 import org.apache.log4j.Logger;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Canvas;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.widgets.Composite;
 import org.jzy3d.chart.factories.IChartComponentFactory;
 import org.jzy3d.plot3d.rendering.canvas.IScreenCanvas;
@@ -17,7 +16,6 @@ import org.jzy3d.plot3d.rendering.view.Renderer3d;
 import org.jzy3d.plot3d.rendering.view.View;
 
 import com.jogamp.nativewindow.ScalableSurface;
-import com.jogamp.newt.awt.NewtCanvasAWT;
 import com.jogamp.newt.event.KeyListener;
 import com.jogamp.newt.event.MouseListener;
 import com.jogamp.newt.opengl.GLWindow;
@@ -31,7 +29,7 @@ import com.jogamp.opengl.util.texture.TextureData;
 import com.jogamp.opengl.util.texture.TextureIO;
 
 /**
- * A Newt canvas wrapped in an AWT {@link Panel}.
+ * A Newt canvas wrapped in an AWT 
  * 
  * Newt is supposed to be faster than any other canvas, either for AWT or Swing.
  * 
@@ -57,10 +55,17 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
             setPixelScale(new float[] { ScalableSurface.IDENTITY_PIXELSCALE, ScalableSurface.IDENTITY_PIXELSCALE });
         
         window.setAutoSwapBufferMode(quality.isAutoSwapBuffer());
-//        if (quality.isAnimated()) {
-//            animator = new Animator(window);
-//            getAnimator().start();
-//        }
+        if (quality.isAnimated()) {
+            animator = new Animator(window);
+            getAnimator().start();
+        }
+        
+        addDisposeListener(new DisposeListener() {
+            public void widgetDisposed(DisposeEvent e)
+            {
+                dispose();
+            }
+        });
 
     }
 

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
@@ -7,6 +7,7 @@ import org.apache.log4j.Logger;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
+import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.jzy3d.chart.factories.IChartComponentFactory;
 import org.jzy3d.plot3d.rendering.canvas.IScreenCanvas;
@@ -45,8 +46,9 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
 
     public CanvasNewtSWT(IChartComponentFactory factory, Scene scene, Quality quality, GLCapabilitiesImmutable glci, boolean traceGL, boolean debugGL) {
     	super(((SWTChartComponentFactory)factory).getComposite(), SWT.NONE);
+    	this.setLayout(new FillLayout());
         window = GLWindow.create(glci);
-        canvas = new NewtCanvasSWT(((SWTChartComponentFactory)factory).getComposite(), SWT.NONE,window);
+        canvas = new NewtCanvasSWT(this, SWT.NONE,window);
         view = scene.newView(this, quality);
         renderer = factory.newRenderer(view, traceGL, debugGL);
         window.addGLEventListener(renderer);
@@ -102,7 +104,6 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
                 if (renderer != null) {
                     renderer.dispose(window);
                 }
-                canvas.dispose();
                 window = null;
                 renderer = null;
                 view = null;

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
@@ -226,5 +226,4 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
     protected Animator animator;
     protected GLWindow window;
     protected NewtCanvasSWT canvas;
-    private static final long serialVersionUID = 8578690050666237742L;
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
@@ -1,0 +1,224 @@
+package org.jzy3d.chart.swt;
+
+import java.awt.BorderLayout;
+import java.awt.Panel;
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.log4j.Logger;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Canvas;
+import org.eclipse.swt.widgets.Composite;
+import org.jzy3d.chart.factories.IChartComponentFactory;
+import org.jzy3d.plot3d.rendering.canvas.IScreenCanvas;
+import org.jzy3d.plot3d.rendering.canvas.Quality;
+import org.jzy3d.plot3d.rendering.scene.Scene;
+import org.jzy3d.plot3d.rendering.view.Renderer3d;
+import org.jzy3d.plot3d.rendering.view.View;
+
+import com.jogamp.nativewindow.ScalableSurface;
+import com.jogamp.newt.awt.NewtCanvasAWT;
+import com.jogamp.newt.event.KeyListener;
+import com.jogamp.newt.event.MouseListener;
+import com.jogamp.newt.opengl.GLWindow;
+import com.jogamp.newt.swt.NewtCanvasSWT;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GLAnimatorControl;
+import com.jogamp.opengl.GLCapabilitiesImmutable;
+import com.jogamp.opengl.GLDrawable;
+import com.jogamp.opengl.util.Animator;
+import com.jogamp.opengl.util.texture.TextureData;
+import com.jogamp.opengl.util.texture.TextureIO;
+
+/**
+ * A Newt canvas wrapped in an AWT {@link Panel}.
+ * 
+ * Newt is supposed to be faster than any other canvas, either for AWT or Swing.
+ * 
+ * If a non AWT panel where required, follow the guidelines given in
+ * {@link IScreenCanvas} documentation.
+ */
+public class CanvasNewtSWT extends Composite implements IScreenCanvas {
+    static Logger LOGGER = Logger.getLogger(CanvasNewtSWT.class);
+    
+    public CanvasNewtSWT(IChartComponentFactory factory, Scene scene, Quality quality, GLCapabilitiesImmutable glci) {
+        this(factory, scene, quality, glci, false, false);
+    }
+
+    public CanvasNewtSWT(IChartComponentFactory factory, Scene scene, Quality quality, GLCapabilitiesImmutable glci, boolean traceGL, boolean debugGL) {
+    	super(((SWTChartComponentFactory)factory).getComposite(), SWT.NONE);
+        window = GLWindow.create(glci);
+        canvas = new NewtCanvasSWT(((SWTChartComponentFactory)factory).getComposite(), SWT.NONE,window);
+        view = scene.newView(this, quality);
+        renderer = factory.newRenderer(view, traceGL, debugGL);
+        window.addGLEventListener(renderer);
+        
+        if(quality.isPreserveViewportSize())
+            setPixelScale(new float[] { ScalableSurface.IDENTITY_PIXELSCALE, ScalableSurface.IDENTITY_PIXELSCALE });
+        
+        window.setAutoSwapBufferMode(quality.isAutoSwapBuffer());
+//        if (quality.isAnimated()) {
+//            animator = new Animator(window);
+//            getAnimator().start();
+//        }
+
+    }
+
+    @Override
+    public void setPixelScale(float[] scale) {
+        //LOGGER.info("setting scale " + scale);
+        if (scale != null)
+            window.setSurfaceScale(scale);
+        else
+            window.setSurfaceScale(new float[] { 1f, 1f });
+    }
+
+    public GLWindow getWindow() {
+        return window;
+    }
+
+    public NewtCanvasSWT getCanvas() {
+        return canvas;
+    }
+
+    @Override
+    public GLDrawable getDrawable() {
+        return window;
+    }
+
+    @Override
+    public void dispose() {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                if (animator != null && animator.isStarted()) {
+                    animator.stop();
+                }
+                if (renderer != null) {
+                    renderer.dispose(window);
+                }
+                canvas.dispose();
+                window = null;
+                renderer = null;
+                view = null;
+                animator = null;
+            }
+        }).start();
+    }
+
+    @Override
+    public void display() {
+        window.display();
+    }
+
+    @Override
+    public void forceRepaint() {
+        display();
+    }
+
+    @Override
+    public GLAnimatorControl getAnimator() {
+        return window.getAnimator();
+    }
+
+    @Override
+    public TextureData screenshot() {
+        renderer.nextDisplayUpdateScreenshot();
+        display();
+        return renderer.getLastScreenshot();
+    }
+
+    @Override
+    public TextureData screenshot(File file) throws IOException {
+        TextureData screen = screenshot();
+        TextureIO.write(screen, file);
+        return screen;
+    }
+
+    @Override
+    public String getDebugInfo() {
+        GL gl = getView().getCurrentGL();
+
+        StringBuffer sb = new StringBuffer();
+        sb.append("Chosen GLCapabilities: " + window.getChosenGLCapabilities() + "\n");
+        sb.append("GL_VENDOR: " + gl.glGetString(GL.GL_VENDOR) + "\n");
+        sb.append("GL_RENDERER: " + gl.glGetString(GL.GL_RENDERER) + "\n");
+        sb.append("GL_VERSION: " + gl.glGetString(GL.GL_VERSION) + "\n");
+        // sb.append("INIT GL IS: " + gl.getClass().getName() + "\n");
+        return sb.toString();
+    }
+
+    /**
+     * Provide the actual renderer width for the open gl camera settings, which
+     * is obtained after a resize event.
+     */
+    @Override
+    public int getRendererWidth() {
+        return (renderer != null ? renderer.getWidth() : 0);
+    }
+
+    /**
+     * Provide the actual renderer height for the open gl camera settings, which
+     * is obtained after a resize event.
+     */
+    @Override
+    public int getRendererHeight() {
+        return (renderer != null ? renderer.getHeight() : 0);
+    }
+
+    @Override
+    public Renderer3d getRenderer() {
+        return renderer;
+    }
+
+    /** Provide a reference to the View that renders into this canvas. */
+    @Override
+    public View getView() {
+        return view;
+    }
+
+    /* */
+
+    public synchronized void addKeyListener(KeyListener l) {
+        getWindow().addKeyListener(l);
+    }
+
+    public void addMouseListener(MouseListener l) {
+        getWindow().addMouseListener(l);
+    }
+
+    public void removeMouseListener(com.jogamp.newt.event.MouseListener l) {
+        getWindow().removeMouseListener(l);
+    }
+
+    public void removeKeyListener(com.jogamp.newt.event.KeyListener l) {
+        getWindow().removeKeyListener(l);
+    }
+
+    @Override
+    public void addMouseController(Object o) {
+        addMouseListener((MouseListener) o);
+    }
+
+    @Override
+    public void addKeyController(Object o) {
+        addKeyListener((KeyListener) o);
+    }
+
+    @Override
+    public void removeMouseController(Object o) {
+        removeMouseListener((MouseListener) o);
+    }
+
+    @Override
+    public void removeKeyController(Object o) {
+        removeKeyListener((KeyListener) o);
+    }
+
+    protected View view;
+    protected Renderer3d renderer;
+    protected Animator animator;
+    protected GLWindow window;
+    protected NewtCanvasSWT canvas;
+    private static final long serialVersionUID = 8578690050666237742L;
+}

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChart.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChart.java
@@ -1,6 +1,5 @@
 package org.jzy3d.chart.swt;
 
-import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.jzy3d.chart.Chart;
 import org.jzy3d.chart.factories.IChartComponentFactory;

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChart.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChart.java
@@ -1,0 +1,17 @@
+package org.jzy3d.chart.swt;
+
+import org.eclipse.swt.widgets.Canvas;
+import org.eclipse.swt.widgets.Composite;
+import org.jzy3d.chart.Chart;
+import org.jzy3d.chart.factories.IChartComponentFactory;
+import org.jzy3d.plot3d.rendering.canvas.Quality;
+
+public class SWTChart extends Chart {
+
+	Composite swtcanvas;
+	
+	  public SWTChart(Composite canvas, IChartComponentFactory factory, Quality quality, String windowingToolkit) {
+	        super(factory, quality, windowingToolkit);
+	        this.swtcanvas = canvas;
+	    }
+}

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChartComponentFactory.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChartComponentFactory.java
@@ -2,26 +2,17 @@ package org.jzy3d.chart.swt;
 
 import java.util.Date;
 
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.UIManager;
-
 import org.apache.log4j.Logger;
-import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.jzy3d.bridge.IFrame;
 import org.jzy3d.chart.Chart;
-import org.jzy3d.chart.controllers.keyboard.camera.AWTCameraKeyController;
 import org.jzy3d.chart.controllers.keyboard.camera.ICameraKeyController;
 import org.jzy3d.chart.controllers.keyboard.camera.NewtCameraKeyController;
-import org.jzy3d.chart.controllers.keyboard.screenshot.AWTScreenshotKeyController;
 import org.jzy3d.chart.controllers.keyboard.screenshot.IScreenshotKeyController;
 import org.jzy3d.chart.controllers.keyboard.screenshot.IScreenshotKeyController.IScreenshotEventListener;
 import org.jzy3d.chart.controllers.keyboard.screenshot.NewtScreenshotKeyController;
-import org.jzy3d.chart.controllers.mouse.camera.AWTCameraMouseController;
 import org.jzy3d.chart.controllers.mouse.camera.ICameraMouseController;
 import org.jzy3d.chart.controllers.mouse.camera.NewtCameraMouseController;
-import org.jzy3d.chart.controllers.mouse.picking.AWTMousePickingController;
 import org.jzy3d.chart.controllers.mouse.picking.IMousePickingController;
 import org.jzy3d.chart.controllers.mouse.picking.NewtMousePickingController;
 import org.jzy3d.chart.factories.ChartComponentFactory;
@@ -32,9 +23,7 @@ import org.jzy3d.maths.Rectangle;
 import org.jzy3d.maths.Utils;
 import org.jzy3d.plot3d.primitives.axes.AxeBox;
 import org.jzy3d.plot3d.primitives.axes.IAxe;
-import org.jzy3d.plot3d.rendering.canvas.CanvasAWT;
 import org.jzy3d.plot3d.rendering.canvas.CanvasNewtAwt;
-import org.jzy3d.plot3d.rendering.canvas.CanvasSwing;
 import org.jzy3d.plot3d.rendering.canvas.ICanvas;
 import org.jzy3d.plot3d.rendering.canvas.OffscreenCanvas;
 import org.jzy3d.plot3d.rendering.canvas.Quality;
@@ -64,7 +53,7 @@ public class SWTChartComponentFactory extends ChartComponentFactory {
     
     public static Chart chart(Composite parent) {
     	SWTChartComponentFactory f = new SWTChartComponentFactory(parent);
-    	return f.newChart(Quality.Intermediate, Toolkit.swt);
+    	return f.newChart(Quality.Advanced, Toolkit.swt);
     }
 
 //    public static Chart chart(Quality quality) {

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChartComponentFactory.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChartComponentFactory.java
@@ -45,36 +45,16 @@ public class SWTChartComponentFactory extends ChartComponentFactory {
     private SWTChartComponentFactory(Composite canvas) {
     	this.canvas = canvas;
     }
-    
-    
-//    public static Chart chart() {
-//        return chart(Quality.Intermediate);
-//    }
-    
+
     public static Chart chart(Composite parent) {
     	SWTChartComponentFactory f = new SWTChartComponentFactory(parent);
-    	return f.newChart(Quality.Advanced, Toolkit.swt);
+    	return f.newChart(Quality.Intermediate, Toolkit.swt_newt);
     }
-
-//    public static Chart chart(Quality quality) {
-//    	SWTChartComponentFactory f = new SWTChartComponentFactory();
-//        return f.newChart(quality, Toolkit.awt/* Toolkit.newt */);
-//    }
-//
-//    public static Chart chart(String toolkit) {
-//    	SWTChartComponentFactory f = new SWTChartComponentFactory();
-//        return f.newChart(Chart.DEFAULT_QUALITY, toolkit);
-//    }
-//
-//    public static Chart chart(Quality quality, Toolkit toolkit) {
-//    	SWTChartComponentFactory f = new SWTChartComponentFactory();
-//        return f.newChart(quality, toolkit);
-//    }
-//
-//    public static Chart chart(Quality quality, String toolkit) {
-//    	SWTChartComponentFactory f = new SWTChartComponentFactory();
-//        return f.newChart(quality, toolkit);
-//    }
+    
+    public static Chart chart(Composite parent, Quality quality) {
+    	SWTChartComponentFactory f = new SWTChartComponentFactory(parent);
+    	return f.newChart(quality, Toolkit.swt_newt);
+    }
 
     /* */
 
@@ -145,7 +125,7 @@ public class SWTChartComponentFactory extends ChartComponentFactory {
         case offscreen:
             Dimension dimension = getCanvasDimension(windowingToolkit);
             return new OffscreenCanvas(factory, scene, quality, capabilities, dimension.width, dimension.height, traceGL, debugGL);
-        case swt:
+        case swt_newt:
         	return new CanvasNewtSWT(factory, scene, quality, capabilities, traceGL, debugGL);
         default:
             throw new RuntimeException("unknown chart type:" + chartType);
@@ -168,19 +148,6 @@ public class SWTChartComponentFactory extends ChartComponentFactory {
     public IChartComponentFactory getFactory() {
         return this;
     }
-//
-//    public JFrame newFrame(JPanel panel) {
-//        try {
-//            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-//        } catch (Exception e) {
-//            // ignore failure to set default look en feel;
-//        }
-//        JFrame frame = new JFrame();
-//        frame.add(panel);
-//        frame.pack();
-//        frame.setVisible(true);
-//        return frame;
-//    }
 
     @Override
     public ICameraMouseController newMouseCameraController(Chart chart) {

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChartComponentFactory.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChartComponentFactory.java
@@ -1,0 +1,240 @@
+package org.jzy3d.chart.swt;
+
+import java.util.Date;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+
+import org.apache.log4j.Logger;
+import org.eclipse.swt.widgets.Canvas;
+import org.eclipse.swt.widgets.Composite;
+import org.jzy3d.bridge.IFrame;
+import org.jzy3d.chart.Chart;
+import org.jzy3d.chart.controllers.keyboard.camera.AWTCameraKeyController;
+import org.jzy3d.chart.controllers.keyboard.camera.ICameraKeyController;
+import org.jzy3d.chart.controllers.keyboard.camera.NewtCameraKeyController;
+import org.jzy3d.chart.controllers.keyboard.screenshot.AWTScreenshotKeyController;
+import org.jzy3d.chart.controllers.keyboard.screenshot.IScreenshotKeyController;
+import org.jzy3d.chart.controllers.keyboard.screenshot.IScreenshotKeyController.IScreenshotEventListener;
+import org.jzy3d.chart.controllers.keyboard.screenshot.NewtScreenshotKeyController;
+import org.jzy3d.chart.controllers.mouse.camera.AWTCameraMouseController;
+import org.jzy3d.chart.controllers.mouse.camera.ICameraMouseController;
+import org.jzy3d.chart.controllers.mouse.camera.NewtCameraMouseController;
+import org.jzy3d.chart.controllers.mouse.picking.AWTMousePickingController;
+import org.jzy3d.chart.controllers.mouse.picking.IMousePickingController;
+import org.jzy3d.chart.controllers.mouse.picking.NewtMousePickingController;
+import org.jzy3d.chart.factories.ChartComponentFactory;
+import org.jzy3d.chart.factories.IChartComponentFactory;
+import org.jzy3d.maths.BoundingBox3d;
+import org.jzy3d.maths.Dimension;
+import org.jzy3d.maths.Rectangle;
+import org.jzy3d.maths.Utils;
+import org.jzy3d.plot3d.primitives.axes.AxeBox;
+import org.jzy3d.plot3d.primitives.axes.IAxe;
+import org.jzy3d.plot3d.rendering.canvas.CanvasAWT;
+import org.jzy3d.plot3d.rendering.canvas.CanvasNewtAwt;
+import org.jzy3d.plot3d.rendering.canvas.CanvasSwing;
+import org.jzy3d.plot3d.rendering.canvas.ICanvas;
+import org.jzy3d.plot3d.rendering.canvas.OffscreenCanvas;
+import org.jzy3d.plot3d.rendering.canvas.Quality;
+import org.jzy3d.plot3d.rendering.scene.Scene;
+import org.jzy3d.plot3d.rendering.view.AWTRenderer3d;
+import org.jzy3d.plot3d.rendering.view.AWTView;
+import org.jzy3d.plot3d.rendering.view.Renderer3d;
+import org.jzy3d.plot3d.rendering.view.View;
+import org.jzy3d.plot3d.rendering.view.layout.ColorbarViewportLayout;
+import org.jzy3d.plot3d.rendering.view.layout.IViewportLayout;
+
+import com.jogamp.opengl.GLCapabilities;
+
+public class SWTChartComponentFactory extends ChartComponentFactory {
+    static Logger logger = Logger.getLogger(SWTChartComponentFactory.class);
+    
+    private Composite canvas;
+    
+    private SWTChartComponentFactory(Composite canvas) {
+    	this.canvas = canvas;
+    }
+    
+    
+//    public static Chart chart() {
+//        return chart(Quality.Intermediate);
+//    }
+    
+    public static Chart chart(Composite parent) {
+    	SWTChartComponentFactory f = new SWTChartComponentFactory(parent);
+    	return f.newChart(Quality.Intermediate, Toolkit.swt);
+    }
+
+//    public static Chart chart(Quality quality) {
+//    	SWTChartComponentFactory f = new SWTChartComponentFactory();
+//        return f.newChart(quality, Toolkit.awt/* Toolkit.newt */);
+//    }
+//
+//    public static Chart chart(String toolkit) {
+//    	SWTChartComponentFactory f = new SWTChartComponentFactory();
+//        return f.newChart(Chart.DEFAULT_QUALITY, toolkit);
+//    }
+//
+//    public static Chart chart(Quality quality, Toolkit toolkit) {
+//    	SWTChartComponentFactory f = new SWTChartComponentFactory();
+//        return f.newChart(quality, toolkit);
+//    }
+//
+//    public static Chart chart(Quality quality, String toolkit) {
+//    	SWTChartComponentFactory f = new SWTChartComponentFactory();
+//        return f.newChart(quality, toolkit);
+//    }
+
+    /* */
+
+    /**
+     * @param toolkit can be used to indicate "offscreen, 800, 600" and thus replace implicit "awt"
+     */
+    @Override
+    public Chart newChart(IChartComponentFactory factory, Quality quality, String toolkit) {
+        return new SWTChart(canvas, factory, quality, toolkit);
+    }
+    
+    public Composite getComposite() {
+    	return canvas;
+    }
+
+    @Override
+    public IAxe newAxe(BoundingBox3d box, View view) {
+        AxeBox axe = new AxeBox(box);
+        axe.setView(view);
+        return axe;
+    }
+
+    @Override
+    public IViewportLayout newViewportLayout() {
+        return new ColorbarViewportLayout();
+    }
+
+    /**
+     * The AWTView support Java2d defined components (tooltips, background
+     * images)
+     */
+    @Override
+    public View newView(Scene scene, ICanvas canvas, Quality quality) {
+        return new AWTView(getFactory(), scene, canvas, quality);
+    }
+
+    /** Provide AWT Texture loading for screenshots */
+    @Override
+    public Renderer3d newRenderer(View view, boolean traceGL, boolean debugGL) {
+        return new AWTRenderer3d(view, traceGL, debugGL);
+    }
+
+    /** bypass reflection used in super implementation */
+    @Override
+    protected IFrame newFrameSwing(Chart chart, Rectangle bounds, String title) {
+        return null;
+    }
+
+    /** bypass reflection used in super implementation */
+    @Override
+    protected IFrame newFrameAWT(Chart chart, Rectangle bounds, String title, String message) {
+        return null;
+    }
+
+    @Override
+    public ICanvas newCanvas(IChartComponentFactory factory, Scene scene, Quality quality, String windowingToolkit, GLCapabilities capabilities) {
+        boolean traceGL = false;
+        boolean debugGL = false;
+        Toolkit chartType = getToolkit(windowingToolkit);
+        switch (chartType) {
+        case awt:
+            return newCanvasAWT(factory, scene, quality, capabilities, traceGL, debugGL);
+        case swing:
+            Logger.getLogger(ChartComponentFactory.class).warn("Swing canvas is deprecated. Use Newt instead");
+            return newCanvasSwing(factory, scene, quality, capabilities, traceGL, debugGL);
+        case newt:
+            return new CanvasNewtAwt(factory, scene, quality, capabilities, traceGL, debugGL);
+        case offscreen:
+            Dimension dimension = getCanvasDimension(windowingToolkit);
+            return new OffscreenCanvas(factory, scene, quality, capabilities, dimension.width, dimension.height, traceGL, debugGL);
+        case swt:
+        	return new CanvasNewtSWT(factory, scene, quality, capabilities, traceGL, debugGL);
+        default:
+            throw new RuntimeException("unknown chart type:" + chartType);
+        }
+    }
+
+    /** bypass reflection used in super implementation */
+    @Override
+    protected ICanvas newCanvasAWT(IChartComponentFactory chartComponentFactory, Scene scene, Quality quality, GLCapabilities capabilities, boolean traceGL, boolean debugGL) {
+        return null;
+    }
+
+    /** bypass reflection used in super implementation */
+    @Override
+    protected ICanvas newCanvasSwing(IChartComponentFactory chartComponentFactory, Scene scene, Quality quality, GLCapabilities capabilities, boolean traceGL, boolean debugGL) {
+        return null;
+    }
+
+    @Override
+    public IChartComponentFactory getFactory() {
+        return this;
+    }
+//
+//    public JFrame newFrame(JPanel panel) {
+//        try {
+//            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+//        } catch (Exception e) {
+//            // ignore failure to set default look en feel;
+//        }
+//        JFrame frame = new JFrame();
+//        frame.add(panel);
+//        frame.pack();
+//        frame.setVisible(true);
+//        return frame;
+//    }
+
+    @Override
+    public ICameraMouseController newMouseCameraController(Chart chart) {
+            return new NewtCameraMouseController(chart);
+    }
+    
+    @Override
+    public IMousePickingController newMousePickingController(Chart chart, int clickWidth) {
+            return new NewtMousePickingController(chart, clickWidth);
+    }
+
+    /**
+     * Output file of screenshot can be configured using {@link IScreenshotKeyController#setFilename(String)}.
+     */
+    @Override
+    public IScreenshotKeyController newKeyboardScreenshotController(Chart chart) {
+        // trigger screenshot on 's' letter
+        String file = SCREENSHOT_FOLDER + "capture-" + Utils.dat2str(new Date(), "yyyy-MM-dd-HH-mm-ss") + ".png";
+        IScreenshotKeyController screenshot = new NewtScreenshotKeyController(chart, file);
+        
+        
+        screenshot.addListener(new IScreenshotEventListener() {
+            @Override
+            public void failedScreenshot(String file, Exception e) {
+                logger.error("Failed to save screenshot to '" + file + "'", e);
+            }
+
+            @Override
+            public void doneScreenshot(String file) {
+                logger.info("Screenshot save to '" + file + "'");
+            }
+        });
+        return screenshot;
+    }
+
+    @Override
+    public ICameraKeyController newKeyboardCameraController(Chart chart) {
+        ICameraKeyController key = new NewtCameraKeyController(chart);
+        return key;
+    }
+
+    @Override
+    public IFrame newFrame(Chart chart, Rectangle bounds, String title) {
+        return null;
+    }
+}


### PR DESCRIPTION
Implementation of charts and factories using swt newt instead of the swt awt bridge.

I've tried to follow similar patterns to the awt classes (except the parent composite is required to construct the swt chart, so needs to passed through the component factory).

Not sure its perfect (still seems to be some awt threads, need to investigate a little further), but certainly works.

Added demos for the bridge and non bridge swt, which both seem to run fine.

Tested in eclipse with OSGI against maven built jzy3d jars packaged in plugin and jogl OSGI bundle.

Happy to get feedback and modify before the request is accepted.