### PR TITLE
bug in #getSerie - new series not added to the map

### DIFF
--- a/jzy3d-api/src/api/org/jzy3d/chart2d/Chart2d.java
+++ b/jzy3d-api/src/api/org/jzy3d/chart2d/Chart2d.java
@@ -53,6 +53,7 @@ public class Chart2d extends AWTChart {
         if (!series.keySet().contains(name)) {
             serie = factory.newSerie(name, type);
             addDrawable(serie.getDrawable());
+            series.put(name,serie);
         } else {
             serie = series.get(name);
         }


### PR DESCRIPTION
#getSerie checks if a serie for the given name already exists, but does not add newly created series to the HashMap.