### PR TITLE
Fix waterfall draw in Windows10 by reversing add of fill and outline

### DIFF
--- a/jzy3d-api/src/api/org/jzy3d/plot3d/primitives/WaterfallComposite.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/primitives/WaterfallComposite.java
@@ -35,8 +35,8 @@ public class WaterfallComposite extends Shape {
 		outline.setWireframeColor(Color.BLACK);
 		outline.setFaceDisplayed(false);
 		
-		add(outline);
 		add(fill);
+		add(outline);
 	}
 	
 	@Override


### PR DESCRIPTION
Waterfall outlines are either missing or split by the fill in windows 10 (demo looks terrible), simple fix is changing the order they are added. This doesn't seem to effect how they are drawn in linux.