### PR TITLE
Squarifier interface, standard implementations and demp

### DIFF
--- a/jzy3d-api/src/api/org/jzy3d/plot3d/rendering/view/View.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/rendering/view/View.java
@@ -31,6 +31,7 @@ import org.jzy3d.plot3d.rendering.view.modes.ViewPositionMode;
 import org.jzy3d.plot3d.transform.Scale;
 import org.jzy3d.plot3d.transform.Transform;
 import org.jzy3d.plot3d.transform.space.SpaceTransformer;
+import org.jzy3d.plot3d.transform.squarifier.ISquarifier;
 
 import com.jogamp.opengl.GL;
 import com.jogamp.opengl.GL2;
@@ -870,6 +871,9 @@ public class View {
         if (Float.isInfinite(lmax) || Float.isNaN(lmax) || lmax == 0)
             lmax = 1;
 
+        if (squarifier != null) {
+        	return squarifier.scale(xLen, yLen, zLen);
+        }
         // Return a scaler
         float xscale = (float) ((double) lmax / (double) xLen);
         float yscale = (float) ((double) lmax / (double) yLen);
@@ -1108,6 +1112,10 @@ public class View {
         this.spaceTransformer = transformer;
     }
 
+    public void setSquarifier(ISquarifier squarifier) {
+    	this.squarifier = squarifier;
+    }
+    
     /* */
 
     /** A view may optionnaly know its parent chart. */
@@ -1139,6 +1147,7 @@ public class View {
     protected Coord3d center;
     protected Coord3d scaling;
     protected BoundingBox3d viewbounds;
+    
 
     protected CameraMode cameraMode;
     protected ViewPositionMode viewmode;
@@ -1179,5 +1188,7 @@ public class View {
     protected boolean slave = false;
 
     protected SpaceTransformer spaceTransformer = new SpaceTransformer();
+    
+    private ISquarifier squarifier;
 
 }

--- a/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/ISquarifier.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/ISquarifier.java
@@ -1,0 +1,9 @@
+package org.jzy3d.plot3d.transform.squarifier;
+
+import org.jzy3d.maths.Coord3d;
+
+public interface ISquarifier {
+	
+	Coord3d scale(float xRange, float yRange, float zRange);
+
+}

--- a/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/ISquarifier.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/ISquarifier.java
@@ -4,6 +4,18 @@ import org.jzy3d.maths.Coord3d;
 
 public interface ISquarifier {
 	
+	/**
+	 * Return a 3D scaling factor to set the aspect ratio of the axes
+	 * 
+	 * The parameters are the current ranges of the x,y and z axes,
+	 * and can be used to connection between the length of the axes
+	 * and the values of the axes or to change the relative lengths.
+	 * 
+	 * @param xRange
+	 * @param yRange
+	 * @param zRange
+	 * @return scaling
+	 */
 	Coord3d scale(float xRange, float yRange, float zRange);
 
 }

--- a/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/XYSquarifier.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/XYSquarifier.java
@@ -3,13 +3,13 @@ package org.jzy3d.plot3d.transform.squarifier;
 import org.jzy3d.maths.Coord3d;
 
 /**
- * XZ square, XY correct aspect ratio
+ * XY square, YZ correct aspect ratio
  */
-public class XZSquarifier implements ISquarifier {
+public class XYSquarifier implements ISquarifier {
 
 	@Override
 	public Coord3d scale(float xRange, float yRange, float zRange) {
-		return new Coord3d(1, 1, xRange/zRange);
+		return new Coord3d(1, xRange/yRange, 1);
 	}
 
 }

--- a/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/XZSquarifier.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/XZSquarifier.java
@@ -1,0 +1,12 @@
+package org.jzy3d.plot3d.transform.squarifier;
+
+import org.jzy3d.maths.Coord3d;
+
+public class XZSquarifier implements ISquarifier {
+
+	@Override
+	public Coord3d scale(float xRange, float yRange, float zRange) {
+		return new Coord3d(1, 1, xRange/zRange);
+	}
+
+}

--- a/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/YXSquarifier.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/YXSquarifier.java
@@ -3,13 +3,13 @@ package org.jzy3d.plot3d.transform.squarifier;
 import org.jzy3d.maths.Coord3d;
 
 /**
- * XZ square, XY correct aspect ratio
+ * XY square, XZ correct aspect ratio
  */
-public class XZSquarifier implements ISquarifier {
+public class YXSquarifier implements ISquarifier {
 
 	@Override
 	public Coord3d scale(float xRange, float yRange, float zRange) {
-		return new Coord3d(1, 1, xRange/zRange);
+		return new Coord3d(yRange/xRange, 1, 1);
 	}
 
 }

--- a/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/YZSquarifier.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/YZSquarifier.java
@@ -3,13 +3,13 @@ package org.jzy3d.plot3d.transform.squarifier;
 import org.jzy3d.maths.Coord3d;
 
 /**
- * XZ square, XY correct aspect ratio
+ * ZY square, XY correct aspect ratio
  */
-public class XZSquarifier implements ISquarifier {
+public class YZSquarifier implements ISquarifier {
 
 	@Override
 	public Coord3d scale(float xRange, float yRange, float zRange) {
-		return new Coord3d(1, 1, xRange/zRange);
+		return new Coord3d(1, zRange/yRange, 1);
 	}
 
 }

--- a/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/ZXSquarifier.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/ZXSquarifier.java
@@ -3,13 +3,13 @@ package org.jzy3d.plot3d.transform.squarifier;
 import org.jzy3d.maths.Coord3d;
 
 /**
- * XZ square, XY correct aspect ratio
+ * XZ square, YZ correct aspect ratio
  */
-public class XZSquarifier implements ISquarifier {
+public class ZXSquarifier implements ISquarifier {
 
 	@Override
 	public Coord3d scale(float xRange, float yRange, float zRange) {
-		return new Coord3d(1, 1, xRange/zRange);
+		return new Coord3d(zRange/xRange, 1, 1);
 	}
 
 }

--- a/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/ZYSquarifier.java
+++ b/jzy3d-api/src/api/org/jzy3d/plot3d/transform/squarifier/ZYSquarifier.java
@@ -3,13 +3,13 @@ package org.jzy3d.plot3d.transform.squarifier;
 import org.jzy3d.maths.Coord3d;
 
 /**
- * XZ square, XY correct aspect ratio
+ * YZ square, XZ correct aspect ratio
  */
-public class XZSquarifier implements ISquarifier {
+public class ZYSquarifier implements ISquarifier {
 
 	@Override
 	public Coord3d scale(float xRange, float yRange, float zRange) {
-		return new Coord3d(1, 1, xRange/zRange);
+		return new Coord3d(1, 1, yRange/zRange);
 	}
 
 }

--- a/jzy3d-tutorials/src/main/java/org/jzy3d/demos/misc/SquarifyDemo.java
+++ b/jzy3d-tutorials/src/main/java/org/jzy3d/demos/misc/SquarifyDemo.java
@@ -12,7 +12,12 @@ import org.jzy3d.plot3d.builder.Mapper;
 import org.jzy3d.plot3d.builder.concrete.OrthonormalGrid;
 import org.jzy3d.plot3d.primitives.Shape;
 import org.jzy3d.plot3d.rendering.canvas.Quality;
+import org.jzy3d.plot3d.transform.squarifier.XYSquarifier;
 import org.jzy3d.plot3d.transform.squarifier.XZSquarifier;
+import org.jzy3d.plot3d.transform.squarifier.YXSquarifier;
+import org.jzy3d.plot3d.transform.squarifier.YZSquarifier;
+import org.jzy3d.plot3d.transform.squarifier.ZXSquarifier;
+import org.jzy3d.plot3d.transform.squarifier.ZYSquarifier;
 
 public class SquarifyDemo extends AbstractAnalysis {
     public static void main(String[] args) throws Exception {

--- a/jzy3d-tutorials/src/main/java/org/jzy3d/demos/misc/SquarifyDemo.java
+++ b/jzy3d-tutorials/src/main/java/org/jzy3d/demos/misc/SquarifyDemo.java
@@ -12,12 +12,7 @@ import org.jzy3d.plot3d.builder.Mapper;
 import org.jzy3d.plot3d.builder.concrete.OrthonormalGrid;
 import org.jzy3d.plot3d.primitives.Shape;
 import org.jzy3d.plot3d.rendering.canvas.Quality;
-import org.jzy3d.plot3d.transform.squarifier.XYSquarifier;
 import org.jzy3d.plot3d.transform.squarifier.XZSquarifier;
-import org.jzy3d.plot3d.transform.squarifier.YXSquarifier;
-import org.jzy3d.plot3d.transform.squarifier.YZSquarifier;
-import org.jzy3d.plot3d.transform.squarifier.ZXSquarifier;
-import org.jzy3d.plot3d.transform.squarifier.ZYSquarifier;
 
 public class SquarifyDemo extends AbstractAnalysis {
     public static void main(String[] args) throws Exception {
@@ -35,7 +30,7 @@ public class SquarifyDemo extends AbstractAnalysis {
         };
 
         // Define range and precision for the function to plot
-        Range range = new Range(-3, 3);
+        Range range = new Range(-2.5f, 2.5f);
         int steps = 80;
         Range yrange = new Range(-5, 5);
 
@@ -47,8 +42,10 @@ public class SquarifyDemo extends AbstractAnalysis {
 
         // Create a chart
         chart = AWTChartComponentFactory.chart(Quality.Intermediate, getCanvasType());
-        chart.getView().setSquarifier(new XZSquarifier());
         
+        //This addition keeps the aspect ratio of the X and Y data
+        //but makes X and Z square
+        chart.getView().setSquarifier(new XZSquarifier());
         chart.getView().setSquared(true);
         chart.getScene().getGraph().add(surface);
     }

--- a/jzy3d-tutorials/src/main/java/org/jzy3d/demos/misc/SquarifyDemo.java
+++ b/jzy3d-tutorials/src/main/java/org/jzy3d/demos/misc/SquarifyDemo.java
@@ -1,0 +1,50 @@
+package org.jzy3d.demos.misc;
+
+import org.jzy3d.analysis.AbstractAnalysis;
+import org.jzy3d.analysis.AnalysisLauncher;
+import org.jzy3d.chart.factories.AWTChartComponentFactory;
+import org.jzy3d.colors.Color;
+import org.jzy3d.colors.ColorMapper;
+import org.jzy3d.colors.colormaps.ColorMapRainbow;
+import org.jzy3d.maths.Range;
+import org.jzy3d.plot3d.builder.Builder;
+import org.jzy3d.plot3d.builder.Mapper;
+import org.jzy3d.plot3d.builder.concrete.OrthonormalGrid;
+import org.jzy3d.plot3d.primitives.Shape;
+import org.jzy3d.plot3d.rendering.canvas.Quality;
+import org.jzy3d.plot3d.transform.squarifier.XZSquarifier;
+
+public class SquarifyDemo extends AbstractAnalysis {
+    public static void main(String[] args) throws Exception {
+        AnalysisLauncher.open(new SquarifyDemo());
+    }
+
+    @Override
+    public void init() {
+        // Define a function to plot
+        Mapper mapper = new Mapper() {
+            @Override
+            public double f(double x, double y) {
+                return x * Math.sin(x * y) *10;
+            }
+        };
+
+        // Define range and precision for the function to plot
+        Range range = new Range(-3, 3);
+        int steps = 80;
+        Range yrange = new Range(-5, 5);
+
+        // Create the object to represent the function over the given range.
+        final Shape surface = Builder.buildOrthonormal(new OrthonormalGrid(range, steps, yrange, steps), mapper);
+        surface.setColorMapper(new ColorMapper(new ColorMapRainbow(), surface.getBounds().getZmin(), surface.getBounds().getZmax(), new Color(1, 1, 1, .5f)));
+        surface.setFaceDisplayed(true);
+        surface.setWireframeDisplayed(false);
+
+        // Create a chart
+        chart = AWTChartComponentFactory.chart(Quality.Intermediate, getCanvasType());
+        chart.getView().setSquarifier(new XZSquarifier());
+        
+        chart.getView().setSquared(true);
+        chart.getScene().getGraph().add(surface);
+    }
+}


### PR DESCRIPTION
For issue #87

Allows two axes (say x and y) to keep the correct aspect ratio, while making another axis pair (say x and z) to be square.

Better for visualisation when two of the axes have the same units but the third doesn't.

A demo has also been included.