### PR TITLE
[CanvasNewtSWT] call Widget.dispose() to release SWT resources and clean up in SWT-project 

### DIFF
--- a/jzy3d-swt/pom.xml
+++ b/jzy3d-swt/pom.xml
@@ -52,6 +52,13 @@
 			<version>4.3</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.eclipse.platform/org.eclipse.jface -->
+		<dependency>
+		    <groupId>org.eclipse.platform</groupId>
+		    <artifactId>org.eclipse.jface</artifactId>
+		    <version>3.18.0</version>
+		</dependency>
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTAnalysisLauncher.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTAnalysisLauncher.java
@@ -1,6 +1,5 @@
 package org.jzy3d.analysis;
 
-
 import java.awt.Component;
 
 import org.eclipse.swt.layout.FillLayout;
@@ -12,24 +11,24 @@ import org.jzy3d.chart.Settings;
 
 public class SWTAnalysisLauncher extends AnalysisLauncher {
 
-	public static void openStaticSWT(IAnalysis demo) throws Exception {
-		Settings.getInstance().setHardwareAccelerated(true);
-		Chart chart = demo.getChart();
+    public static void openStaticSWT(IAnalysis demo) throws Exception {
+        Settings.getInstance().setHardwareAccelerated(true);
+        Chart chart = demo.getChart();
 
-		Display display = new Display();
-		Shell shell = new Shell(display);
-		shell.setLayout(new FillLayout());
-		Bridge.adapt(shell, (Component) chart.getCanvas());
+        Display display = new Display();
+        Shell shell = new Shell(display);
+        shell.setLayout(new FillLayout());
+        Bridge.adapt(shell, (Component) chart.getCanvas());
 
-		shell.setText(demo.getName());
-		shell.setSize(800, 600);
-		shell.open();
+        shell.setText(demo.getName());
+        shell.setSize(800, 600);
+        shell.open();
 
-		while (!shell.isDisposed()) {
-			if (!display.readAndDispatch())
-				display.sleep();
-		}
-		display.dispose();
-	}
+        while (!shell.isDisposed()) {
+            if (!display.readAndDispatch())
+                display.sleep();
+        }
+        display.dispose();
+    }
 
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTAnalysisLauncher.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTAnalysisLauncher.java
@@ -25,10 +25,10 @@ public class SWTAnalysisLauncher extends AnalysisLauncher {
         shell.open();
 
         while (!shell.isDisposed()) {
-            if (!display.readAndDispatch())
+            if (!display.readAndDispatch()) {
                 display.sleep();
+            }
         }
         display.dispose();
     }
-
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTBridgeDemo.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTBridgeDemo.java
@@ -55,11 +55,10 @@ public class SWTBridgeDemo {
         shell.open();
 
         while (!shell.isDisposed()) {
-            if (!display.readAndDispatch())
+            if (!display.readAndDispatch()) {
                 display.sleep();
+            }
         }
         display.dispose();
-
     }
-
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTBridgeDemo.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTBridgeDemo.java
@@ -21,8 +21,8 @@ import org.jzy3d.plot3d.rendering.canvas.Quality;
 
 public class SWTBridgeDemo {
 
-	public static void main(String[] args) {
-		Mapper mapper = new Mapper() {
+    public static void main(String[] args) {
+        Mapper mapper = new Mapper() {
             @Override
             public double f(double x, double y) {
                 return x * Math.sin(x * y);
@@ -42,26 +42,24 @@ public class SWTBridgeDemo {
         // Create a chart
         Chart chart = AWTChartComponentFactory.chart(Quality.Advanced, "awt");
         chart.getScene().getGraph().add(surface);
-        
+
         Settings.getInstance().setHardwareAccelerated(true);
 
-		Display display = new Display();
-		Shell shell = new Shell(display);
-		shell.setLayout(new FillLayout());
-		Bridge.adapt(shell, (Component) chart.getCanvas());
+        Display display = new Display();
+        Shell shell = new Shell(display);
+        shell.setLayout(new FillLayout());
+        Bridge.adapt(shell, (Component) chart.getCanvas());
 
-		shell.setText("name");
-		shell.setSize(800, 600);
-		shell.open();
+        shell.setText("name");
+        shell.setSize(800, 600);
+        shell.open();
 
-		while (!shell.isDisposed()) {
-			if (!display.readAndDispatch())
-				display.sleep();
-		}
-		display.dispose();
+        while (!shell.isDisposed()) {
+            if (!display.readAndDispatch())
+                display.sleep();
+        }
+        display.dispose();
 
-	}
-	
-	
+    }
 
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTDemo.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTDemo.java
@@ -43,7 +43,6 @@ public class SWTDemo {
         Display display = new Display();
         Shell shell = new Shell(display);
         shell.setLayout(new FillLayout());
-        // Bridge.adapt(shell, (Component) chart.getCanvas());
 
         Chart chart = SWTChartComponentFactory.chart(shell);
         chart.getScene().getGraph().add(surface);
@@ -55,11 +54,10 @@ public class SWTDemo {
         shell.open();
 
         while (!shell.isDisposed()) {
-            if (!display.readAndDispatch())
+            if (!display.readAndDispatch()) {
                 display.sleep();
+            }
         }
         display.dispose();
-
     }
-
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTDemo.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/analysis/SWTDemo.java
@@ -18,8 +18,8 @@ import org.jzy3d.plot3d.primitives.Shape;
 
 public class SWTDemo {
 
-	public static void main(String[] args) {
-		Mapper mapper = new Mapper() {
+    public static void main(String[] args) {
+        Mapper mapper = new Mapper() {
             @Override
             public double f(double x, double y) {
                 return x * Math.sin(x * y);
@@ -37,32 +37,29 @@ public class SWTDemo {
         surface.setWireframeDisplayed(false);
 
         // Create a chart
-        
-        
+
         Settings.getInstance().setHardwareAccelerated(true);
 
-		Display display = new Display();
-		Shell shell = new Shell(display);
-		shell.setLayout(new FillLayout());
-//		Bridge.adapt(shell, (Component) chart.getCanvas());
-		
-		Chart chart = SWTChartComponentFactory.chart(shell);
+        Display display = new Display();
+        Shell shell = new Shell(display);
+        shell.setLayout(new FillLayout());
+        // Bridge.adapt(shell, (Component) chart.getCanvas());
+
+        Chart chart = SWTChartComponentFactory.chart(shell);
         chart.getScene().getGraph().add(surface);
-        
+
         ChartLauncher.openChart(chart);
 
-		shell.setText("name");
-		shell.setSize(800, 600);
-		shell.open();
+        shell.setText("name");
+        shell.setSize(800, 600);
+        shell.open();
 
-		while (!shell.isDisposed()) {
-			if (!display.readAndDispatch())
-				display.sleep();
-		}
-		display.dispose();
+        while (!shell.isDisposed()) {
+            if (!display.readAndDispatch())
+                display.sleep();
+        }
+        display.dispose();
 
-	}
-	
-	
+    }
 
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/bridge/swt/Bridge.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/bridge/swt/Bridge.java
@@ -11,9 +11,8 @@ import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 
-/** 
- * Adapts an AWT component into an SWT container. 
- * 
+/**
+ * Adapts an AWT component into an SWT container.
  * The following piece of code shows a convenient way of porting an AWT component
  * to SWT:<br>
  * <br>
@@ -25,16 +24,14 @@ import org.eclipse.swt.widgets.Composite;
  *     }</ul>
  * }</ul>
  * </code><br>
- * 
- * Important notice: AWT components may trigger events (mouse, keyboard, component 
+ * Important notice: AWT components may trigger events (mouse, keyboard, component
  * events, etc). When attaching a listener on a bridged AWT component that is supposed
- * to modify an SWT widget (such as a text field), it is required to perform 
+ * to modify an SWT widget (such as a text field), it is required to perform
  * this modification into the SWT UI event queue. If not, the target SWT component
  * will throw a {@link org.eclipse.swt.SWTException} with message "Invalid thread access".
  * Indeed, all SWT widgets check that they are modified inside the UI thread.<br>
  * <br>
  * Thus, it is suggested to compute events this way:<br>
- * 
  * <code>
  * Text    info = new Text(parent, SWT.None);<br>
  * SWTplot plot = new SWTplot(parent);<br>
@@ -47,58 +44,56 @@ import org.eclipse.swt.widgets.Composite;
  * });<br>
  * </code><br>
  * <br>
- * 
- * 
- * 
  * If problems are encountered with the Bridge, it is possible to check:<br>
  * http://wiki.eclipse.org/Albireo_SWT_AWT_bugs<br>
  * http://www.eclipsezone.com/eclipse/forums/t45697.html<br>
  * 
  * @author Martin Pernollet
- *
  */
 public class Bridge {
-	public static void adapt(Composite containerSWT, final Component componentAWT){
-		Composite embedder = new Composite(containerSWT, SWT.EMBEDDED);
-		embedder.setLayoutData(new GridData(GridData.FILL_BOTH));
-		
-		final Frame frame = SWT_AWT.new_Frame(embedder);
-		frame.add(componentAWT);
-		
-		// disposing the frame cleanly
-		embedder.addDisposeListener(new DisposeListener(){
-			@Override
-            public void widgetDisposed(DisposeEvent arg0) {
-				EventQueue.invokeLater(new Runnable () {
-					@Override
-                    public void run () {
-						//System.out.println("Bridge is disposing frame containing " + componentAWT.getName() + " - " + componentAWT.getClass());
-						frame.dispose();
-						// the awt component is supposed to be disposed by the user
-					}
-				});
-			}
-		});
-	}
+    public static void adapt(Composite containerSWT, final Component componentAWT) {
+        Composite embedder = new Composite(containerSWT, SWT.EMBEDDED);
+        embedder.setLayoutData(new GridData(GridData.FILL_BOTH));
 
-	public static void adaptIn(Composite embedder, final Component componentAWT) {
-		final Frame frame = SWT_AWT.new_Frame(embedder);
-		frame.add(componentAWT);
+        final Frame frame = SWT_AWT.new_Frame(embedder);
+        frame.add(componentAWT);
 
-		// disposing the frame cleanly
-		embedder.addDisposeListener(new DisposeListener(){
-			@Override
+        // disposing the frame cleanly
+        embedder.addDisposeListener(new DisposeListener() {
+            @Override
             public void widgetDisposed(DisposeEvent arg0) {
-				EventQueue.invokeLater(new Runnable () {
-					@Override
-                    public void run () {
-						//System.out.println("Bridge is disposing frame containing " + componentAWT.getName() + " - " + componentAWT.getClass());
-						frame.dispose();
-						// the awt component is supposed to be disposed by the user
-					}
-				});
-			}
-		});
-	}
+                EventQueue.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        // System.out.println("Bridge is disposing frame containing " + componentAWT.getName() + " - " +
+                        // componentAWT.getClass());
+                        frame.dispose();
+                        // the awt component is supposed to be disposed by the user
+                    }
+                });
+            }
+        });
+    }
+
+    public static void adaptIn(Composite embedder, final Component componentAWT) {
+        final Frame frame = SWT_AWT.new_Frame(embedder);
+        frame.add(componentAWT);
+
+        // disposing the frame cleanly
+        embedder.addDisposeListener(new DisposeListener() {
+            @Override
+            public void widgetDisposed(DisposeEvent arg0) {
+                EventQueue.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        // System.out.println("Bridge is disposing frame containing " + componentAWT.getName() + " - " +
+                        // componentAWT.getClass());
+                        frame.dispose();
+                        // the awt component is supposed to be disposed by the user
+                    }
+                });
+            }
+        });
+    }
 
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/bridge/swt/Bridge.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/bridge/swt/Bridge.java
@@ -6,8 +6,6 @@ import java.awt.Frame;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.awt.SWT_AWT;
-import org.eclipse.swt.events.DisposeEvent;
-import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 
@@ -47,32 +45,16 @@ import org.eclipse.swt.widgets.Composite;
  * If problems are encountered with the Bridge, it is possible to check:<br>
  * http://wiki.eclipse.org/Albireo_SWT_AWT_bugs<br>
  * http://www.eclipsezone.com/eclipse/forums/t45697.html<br>
- * 
+ *
  * @author Martin Pernollet
  */
 public class Bridge {
+
     public static void adapt(Composite containerSWT, final Component componentAWT) {
         Composite embedder = new Composite(containerSWT, SWT.EMBEDDED);
         embedder.setLayoutData(new GridData(GridData.FILL_BOTH));
 
-        final Frame frame = SWT_AWT.new_Frame(embedder);
-        frame.add(componentAWT);
-
-        // disposing the frame cleanly
-        embedder.addDisposeListener(new DisposeListener() {
-            @Override
-            public void widgetDisposed(DisposeEvent arg0) {
-                EventQueue.invokeLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        // System.out.println("Bridge is disposing frame containing " + componentAWT.getName() + " - " +
-                        // componentAWT.getClass());
-                        frame.dispose();
-                        // the awt component is supposed to be disposed by the user
-                    }
-                });
-            }
-        });
+        adaptIn(embedder, componentAWT);
     }
 
     public static void adaptIn(Composite embedder, final Component componentAWT) {
@@ -80,20 +62,7 @@ public class Bridge {
         frame.add(componentAWT);
 
         // disposing the frame cleanly
-        embedder.addDisposeListener(new DisposeListener() {
-            @Override
-            public void widgetDisposed(DisposeEvent arg0) {
-                EventQueue.invokeLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        // System.out.println("Bridge is disposing frame containing " + componentAWT.getName() + " - " +
-                        // componentAWT.getClass());
-                        frame.dispose();
-                        // the awt component is supposed to be disposed by the user
-                    }
-                });
-            }
-        });
+        embedder.addDisposeListener(e -> EventQueue.invokeLater(frame::dispose));
+        // the awt component is supposed to be disposed by the user
     }
-
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/bridge/swt/FrameSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/bridge/swt/FrameSWT.java
@@ -20,7 +20,6 @@ public class FrameSWT implements IFrame {
 
     @Override
     public void initialize(Chart chart, Rectangle bounds, String title) {
-        this.chart = chart;
 
         Display display = new Display();
         Shell shell = new Shell(display);
@@ -32,15 +31,13 @@ public class FrameSWT implements IFrame {
         shell.open();
 
         while (!shell.isDisposed()) {
-            if (!display.readAndDispatch())
+            if (!display.readAndDispatch()) {
                 display.sleep();
+            }
         }
-        this.chart.dispose();
-        this.chart = null;
+        chart.dispose();
         display.dispose();
     }
-
-    private Chart chart;
 
     @Override
     public void initialize(Chart chart, Rectangle bounds, String title, String message) {

--- a/jzy3d-swt/src/main/java/org/jzy3d/bridge/swt/FrameSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/bridge/swt/FrameSWT.java
@@ -11,40 +11,39 @@ import org.jzy3d.maths.Rectangle;
 
 public class FrameSWT implements IFrame {
 
-	public FrameSWT() {
-	}
+    public FrameSWT() {
+    }
 
-	public FrameSWT(Chart chart, Rectangle bounds, String title) {
-		initialize(chart, bounds, title);
-	}
+    public FrameSWT(Chart chart, Rectangle bounds, String title) {
+        initialize(chart, bounds, title);
+    }
 
-	@Override
+    @Override
     public void initialize(Chart chart, Rectangle bounds, String title) {
-		this.chart = chart;
+        this.chart = chart;
 
-		Display display = new Display();
-		Shell shell = new Shell(display);
+        Display display = new Display();
+        Shell shell = new Shell(display);
 
-		shell.setLayout(new FillLayout());
-		shell.setBounds(bounds.x, bounds.y, bounds.width, bounds.height);
-		shell.setText(title + "[SWT]");
-		Bridge.adapt(shell, (Component) chart.getCanvas());
-		shell.open();
+        shell.setLayout(new FillLayout());
+        shell.setBounds(bounds.x, bounds.y, bounds.width, bounds.height);
+        shell.setText(title + "[SWT]");
+        Bridge.adapt(shell, (Component) chart.getCanvas());
+        shell.open();
 
-		while (!shell.isDisposed()) {
-			if (!display.readAndDispatch())
-				display.sleep();
-		}
-		this.chart.dispose();
-		this.chart = null;
-		display.dispose();
-	}
+        while (!shell.isDisposed()) {
+            if (!display.readAndDispatch())
+                display.sleep();
+        }
+        this.chart.dispose();
+        this.chart = null;
+        display.dispose();
+    }
 
-	private Chart chart;
+    private Chart chart;
 
-	@Override
-	public void initialize(Chart chart, Rectangle bounds, String title,
-			String message) {
-		initialize(chart, bounds, title);
-	}
+    @Override
+    public void initialize(Chart chart, Rectangle bounds, String title, String message) {
+        initialize(chart, bounds, title);
+    }
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/bridge/swt/ImageConverter.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/bridge/swt/ImageConverter.java
@@ -11,106 +11,96 @@ import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.RGB;
 
 public class ImageConverter {
-	public static ImageData toSWT(BufferedImage bufferedImage) {
-		if (bufferedImage.getColorModel() instanceof DirectColorModel) {
-			DirectColorModel colorModel = (DirectColorModel) bufferedImage.getColorModel();
-			PaletteData palette = new PaletteData(colorModel.getRedMask(), colorModel.getGreenMask(), colorModel.getBlueMask());
-			ImageData data = new ImageData(bufferedImage.getWidth(), bufferedImage.getHeight(), colorModel.getPixelSize(), palette);
-			WritableRaster raster = bufferedImage.getRaster();
-			int[] pixelArray = new int[4];
-			for (int y = 0; y < data.height; y++) {
-				for (int x = 0; x < data.width; x++) {
-					raster.getPixel(x, y, pixelArray);
-					int pixel = palette.getPixel(new RGB(pixelArray[0], pixelArray[1], pixelArray[2]));
-					data.setPixel(x, y, pixel);
-				}
-			}
-			return data;
-		} else if (bufferedImage.getColorModel() instanceof IndexColorModel) {
-			IndexColorModel colorModel = (IndexColorModel) bufferedImage
-					.getColorModel();
-			int size = colorModel.getMapSize();
-			byte[] reds = new byte[size];
-			byte[] greens = new byte[size];
-			byte[] blues = new byte[size];
-			colorModel.getReds(reds);
-			colorModel.getGreens(greens);
-			colorModel.getBlues(blues);
-			RGB[] rgbs = new RGB[size];
-			for (int i = 0; i < rgbs.length; i++) {
-				rgbs[i] = new RGB(reds[i] & 0xFF, greens[i] & 0xFF,
-						blues[i] & 0xFF);
-			}
-			PaletteData palette = new PaletteData(rgbs);
-			ImageData data = new ImageData(bufferedImage.getWidth(),
-					bufferedImage.getHeight(), colorModel.getPixelSize(),
-					palette);
-			data.transparentPixel = colorModel.getTransparentPixel();
-			WritableRaster raster = bufferedImage.getRaster();
-			int[] pixelArray = new int[1];
-			for (int y = 0; y < data.height; y++) {
-				for (int x = 0; x < data.width; x++) {
-					raster.getPixel(x, y, pixelArray);
-					data.setPixel(x, y, pixelArray[0]);
-				}
-			}
-			return data;
-		}
-		return null;
-	}
+    public static ImageData toSWT(BufferedImage bufferedImage) {
+        if (bufferedImage.getColorModel() instanceof DirectColorModel) {
+            DirectColorModel colorModel = (DirectColorModel) bufferedImage.getColorModel();
+            PaletteData palette = new PaletteData(colorModel.getRedMask(), colorModel.getGreenMask(), colorModel.getBlueMask());
+            ImageData data = new ImageData(bufferedImage.getWidth(), bufferedImage.getHeight(), colorModel.getPixelSize(), palette);
+            WritableRaster raster = bufferedImage.getRaster();
+            int[] pixelArray = new int[4];
+            for (int y = 0; y < data.height; y++) {
+                for (int x = 0; x < data.width; x++) {
+                    raster.getPixel(x, y, pixelArray);
+                    int pixel = palette.getPixel(new RGB(pixelArray[0], pixelArray[1], pixelArray[2]));
+                    data.setPixel(x, y, pixel);
+                }
+            }
+            return data;
+        } else if (bufferedImage.getColorModel() instanceof IndexColorModel) {
+            IndexColorModel colorModel = (IndexColorModel) bufferedImage.getColorModel();
+            int size = colorModel.getMapSize();
+            byte[] reds = new byte[size];
+            byte[] greens = new byte[size];
+            byte[] blues = new byte[size];
+            colorModel.getReds(reds);
+            colorModel.getGreens(greens);
+            colorModel.getBlues(blues);
+            RGB[] rgbs = new RGB[size];
+            for (int i = 0; i < rgbs.length; i++) {
+                rgbs[i] = new RGB(reds[i] & 0xFF, greens[i] & 0xFF, blues[i] & 0xFF);
+            }
+            PaletteData palette = new PaletteData(rgbs);
+            ImageData data = new ImageData(bufferedImage.getWidth(), bufferedImage.getHeight(), colorModel.getPixelSize(), palette);
+            data.transparentPixel = colorModel.getTransparentPixel();
+            WritableRaster raster = bufferedImage.getRaster();
+            int[] pixelArray = new int[1];
+            for (int y = 0; y < data.height; y++) {
+                for (int x = 0; x < data.width; x++) {
+                    raster.getPixel(x, y, pixelArray);
+                    data.setPixel(x, y, pixelArray[0]);
+                }
+            }
+            return data;
+        }
+        return null;
+    }
 
-	public static BufferedImage toAWT(ImageData data) {
-		ColorModel colorModel = null;
-		PaletteData palette = data.palette;
-		if (palette.isDirect) {
-			colorModel = new DirectColorModel(data.depth, palette.redMask, palette.greenMask, palette.blueMask);
-			BufferedImage bufferedImage = new BufferedImage(colorModel,
-					colorModel.createCompatibleWritableRaster(data.width,
-							data.height), false, null);
-			WritableRaster raster = bufferedImage.getRaster();
-			int[] pixelArray = new int[3];
-			for (int y = 0; y < data.height; y++) {
-				for (int x = 0; x < data.width; x++) {
-					int pixel = data.getPixel(x, y);
-					RGB rgb = palette.getRGB(pixel);
-					pixelArray[0] = rgb.red;
-					pixelArray[1] = rgb.green;
-					pixelArray[2] = rgb.blue;
-					raster.setPixels(x, y, 1, 1, pixelArray);
-				}
-			}
-			return bufferedImage;
-		} else {
-			RGB[] rgbs = palette.getRGBs();
-			byte[] red = new byte[rgbs.length];
-			byte[] green = new byte[rgbs.length];
-			byte[] blue = new byte[rgbs.length];
-			for (int i = 0; i < rgbs.length; i++) {
-				RGB rgb = rgbs[i];
-				red[i] = (byte) rgb.red;
-				green[i] = (byte) rgb.green;
-				blue[i] = (byte) rgb.blue;
-			}
-			if (data.transparentPixel != -1) {
-				colorModel = new IndexColorModel(data.depth, rgbs.length, red,
-						green, blue, data.transparentPixel);
-			} else {
-				colorModel = new IndexColorModel(data.depth, rgbs.length, red,
-						green, blue);
-			}
-			BufferedImage bufferedImage = new BufferedImage(colorModel,
-					colorModel.createCompatibleWritableRaster(data.width,
-							data.height), false, null);
-			WritableRaster raster = bufferedImage.getRaster();
-			int[] pixelArray = new int[1];
-			for (int y = 0; y < data.height; y++) {
-				for (int x = 0; x < data.width; x++) {
-					int pixel = data.getPixel(x, y);
-					pixelArray[0] = pixel;
-					raster.setPixel(x, y, pixelArray);
-				}
-			}
-			return bufferedImage;
-		}
-	}
+    public static BufferedImage toAWT(ImageData data) {
+        ColorModel colorModel = null;
+        PaletteData palette = data.palette;
+        if (palette.isDirect) {
+            colorModel = new DirectColorModel(data.depth, palette.redMask, palette.greenMask, palette.blueMask);
+            BufferedImage bufferedImage = new BufferedImage(colorModel, colorModel.createCompatibleWritableRaster(data.width, data.height), false, null);
+            WritableRaster raster = bufferedImage.getRaster();
+            int[] pixelArray = new int[3];
+            for (int y = 0; y < data.height; y++) {
+                for (int x = 0; x < data.width; x++) {
+                    int pixel = data.getPixel(x, y);
+                    RGB rgb = palette.getRGB(pixel);
+                    pixelArray[0] = rgb.red;
+                    pixelArray[1] = rgb.green;
+                    pixelArray[2] = rgb.blue;
+                    raster.setPixels(x, y, 1, 1, pixelArray);
+                }
+            }
+            return bufferedImage;
+        } else {
+            RGB[] rgbs = palette.getRGBs();
+            byte[] red = new byte[rgbs.length];
+            byte[] green = new byte[rgbs.length];
+            byte[] blue = new byte[rgbs.length];
+            for (int i = 0; i < rgbs.length; i++) {
+                RGB rgb = rgbs[i];
+                red[i] = (byte) rgb.red;
+                green[i] = (byte) rgb.green;
+                blue[i] = (byte) rgb.blue;
+            }
+            if (data.transparentPixel != -1) {
+                colorModel = new IndexColorModel(data.depth, rgbs.length, red, green, blue, data.transparentPixel);
+            } else {
+                colorModel = new IndexColorModel(data.depth, rgbs.length, red, green, blue);
+            }
+            BufferedImage bufferedImage = new BufferedImage(colorModel, colorModel.createCompatibleWritableRaster(data.width, data.height), false, null);
+            WritableRaster raster = bufferedImage.getRaster();
+            int[] pixelArray = new int[1];
+            for (int y = 0; y < data.height; y++) {
+                for (int x = 0; x < data.width; x++) {
+                    int pixel = data.getPixel(x, y);
+                    pixelArray[0] = pixel;
+                    raster.setPixel(x, y, pixelArray);
+                }
+            }
+            return bufferedImage;
+        }
+    }
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
@@ -57,8 +57,18 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
             getAnimator().start();
         }
 
-        addDisposeListener(e -> dispose());
-
+        addDisposeListener(e -> new Thread(() -> {
+            if (animator != null && animator.isStarted()) {
+                animator.stop();
+            }
+            if (renderer != null) {
+                renderer.dispose(window);
+            }
+            window = null;
+            renderer = null;
+            view = null;
+            animator = null;
+        }).start());
     }
 
     @Override
@@ -81,23 +91,6 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
     @Override
     public GLDrawable getDrawable() {
         return window;
-    }
-
-    @Override
-    public void dispose() {
-        super.dispose();
-        new Thread(() -> {
-            if (animator != null && animator.isStarted()) {
-                animator.stop();
-            }
-            if (renderer != null) {
-                renderer.dispose(window);
-            }
-            window = null;
-            renderer = null;
-            view = null;
-            animator = null;
-        }).start();
     }
 
     @Override

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
@@ -3,10 +3,7 @@ package org.jzy3d.chart.swt;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.log4j.Logger;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.DisposeEvent;
-import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.jzy3d.chart.factories.IChartComponentFactory;
@@ -36,7 +33,6 @@ import com.jogamp.opengl.util.texture.TextureIO;
  * {@link IScreenCanvas} documentation.
  */
 public class CanvasNewtSWT extends Composite implements IScreenCanvas {
-    static Logger LOGGER = Logger.getLogger(CanvasNewtSWT.class);
 
     public CanvasNewtSWT(IChartComponentFactory factory, Scene scene, Quality quality, GLCapabilitiesImmutable glci) {
         this(factory, scene, quality, glci, false, false);
@@ -51,8 +47,9 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
         renderer = factory.newRenderer(view, traceGL, debugGL);
         window.addGLEventListener(renderer);
 
-        if (quality.isPreserveViewportSize())
+        if (quality.isPreserveViewportSize()) {
             setPixelScale(new float[] { ScalableSurface.IDENTITY_PIXELSCALE, ScalableSurface.IDENTITY_PIXELSCALE });
+        }
 
         window.setAutoSwapBufferMode(quality.isAutoSwapBuffer());
         if (quality.isAnimated()) {
@@ -60,21 +57,17 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
             getAnimator().start();
         }
 
-        addDisposeListener(new DisposeListener() {
-            public void widgetDisposed(DisposeEvent e) {
-                dispose();
-            }
-        });
+        addDisposeListener(e -> dispose());
 
     }
 
     @Override
     public void setPixelScale(float[] scale) {
-        // LOGGER.info("setting scale " + scale);
-        if (scale != null)
+        if (scale != null) {
             window.setSurfaceScale(scale);
-        else
+        } else {
             window.setSurfaceScale(new float[] { 1f, 1f });
+        }
     }
 
     public GLWindow getWindow() {
@@ -93,20 +86,17 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
     @Override
     public void dispose() {
         super.dispose();
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                if (animator != null && animator.isStarted()) {
-                    animator.stop();
-                }
-                if (renderer != null) {
-                    renderer.dispose(window);
-                }
-                window = null;
-                renderer = null;
-                view = null;
-                animator = null;
+        new Thread(() -> {
+            if (animator != null && animator.isStarted()) {
+                animator.stop();
             }
+            if (renderer != null) {
+                renderer.dispose(window);
+            }
+            window = null;
+            renderer = null;
+            view = null;
+            animator = null;
         }).start();
     }
 
@@ -143,12 +133,11 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
     public String getDebugInfo() {
         GL gl = getView().getCurrentGL();
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("Chosen GLCapabilities: " + window.getChosenGLCapabilities() + "\n");
         sb.append("GL_VENDOR: " + gl.glGetString(GL.GL_VENDOR) + "\n");
         sb.append("GL_RENDERER: " + gl.glGetString(GL.GL_RENDERER) + "\n");
         sb.append("GL_VERSION: " + gl.glGetString(GL.GL_VERSION) + "\n");
-        // sb.append("INIT GL IS: " + gl.getClass().getName() + "\n");
         return sb.toString();
     }
 

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
@@ -95,6 +95,7 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
 
     @Override
     public void dispose() {
+        super.dispose();
         new Thread(new Runnable() {
             @Override
             public void run() {

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/CanvasNewtSWT.java
@@ -30,41 +30,38 @@ import com.jogamp.opengl.util.texture.TextureData;
 import com.jogamp.opengl.util.texture.TextureIO;
 
 /**
- * A Newt canvas wrapped in an AWT 
- * 
+ * A Newt canvas wrapped in an AWT
  * Newt is supposed to be faster than any other canvas, either for AWT or Swing.
- * 
  * If a non AWT panel where required, follow the guidelines given in
  * {@link IScreenCanvas} documentation.
  */
 public class CanvasNewtSWT extends Composite implements IScreenCanvas {
     static Logger LOGGER = Logger.getLogger(CanvasNewtSWT.class);
-    
+
     public CanvasNewtSWT(IChartComponentFactory factory, Scene scene, Quality quality, GLCapabilitiesImmutable glci) {
         this(factory, scene, quality, glci, false, false);
     }
 
     public CanvasNewtSWT(IChartComponentFactory factory, Scene scene, Quality quality, GLCapabilitiesImmutable glci, boolean traceGL, boolean debugGL) {
-    	super(((SWTChartComponentFactory)factory).getComposite(), SWT.NONE);
-    	this.setLayout(new FillLayout());
+        super(((SWTChartComponentFactory) factory).getComposite(), SWT.NONE);
+        this.setLayout(new FillLayout());
         window = GLWindow.create(glci);
-        canvas = new NewtCanvasSWT(this, SWT.NONE,window);
+        canvas = new NewtCanvasSWT(this, SWT.NONE, window);
         view = scene.newView(this, quality);
         renderer = factory.newRenderer(view, traceGL, debugGL);
         window.addGLEventListener(renderer);
-        
-        if(quality.isPreserveViewportSize())
+
+        if (quality.isPreserveViewportSize())
             setPixelScale(new float[] { ScalableSurface.IDENTITY_PIXELSCALE, ScalableSurface.IDENTITY_PIXELSCALE });
-        
+
         window.setAutoSwapBufferMode(quality.isAutoSwapBuffer());
         if (quality.isAnimated()) {
             animator = new Animator(window);
             getAnimator().start();
         }
-        
+
         addDisposeListener(new DisposeListener() {
-            public void widgetDisposed(DisposeEvent e)
-            {
+            public void widgetDisposed(DisposeEvent e) {
                 dispose();
             }
         });
@@ -73,7 +70,7 @@ public class CanvasNewtSWT extends Composite implements IScreenCanvas {
 
     @Override
     public void setPixelScale(float[] scale) {
-        //LOGGER.info("setting scale " + scale);
+        // LOGGER.info("setting scale " + scale);
         if (scale != null)
             window.setSurfaceScale(scale);
         else

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChart.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChart.java
@@ -7,10 +7,10 @@ import org.jzy3d.plot3d.rendering.canvas.Quality;
 
 public class SWTChart extends Chart {
 
-	Composite swtcanvas;
-	
-	  public SWTChart(Composite canvas, IChartComponentFactory factory, Quality quality, String windowingToolkit) {
-	        super(factory, quality, windowingToolkit);
-	        this.swtcanvas = canvas;
-	    }
+    Composite swtcanvas;
+
+    public SWTChart(Composite canvas, IChartComponentFactory factory, Quality quality, String windowingToolkit) {
+        super(factory, quality, windowingToolkit);
+        this.swtcanvas = canvas;
+    }
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChartComponentFactory.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChartComponentFactory.java
@@ -39,21 +39,21 @@ import com.jogamp.opengl.GLCapabilities;
 
 public class SWTChartComponentFactory extends ChartComponentFactory {
     static Logger logger = Logger.getLogger(SWTChartComponentFactory.class);
-    
+
     private Composite canvas;
-    
+
     private SWTChartComponentFactory(Composite canvas) {
-    	this.canvas = canvas;
+        this.canvas = canvas;
     }
 
     public static Chart chart(Composite parent) {
-    	SWTChartComponentFactory f = new SWTChartComponentFactory(parent);
-    	return f.newChart(Quality.Intermediate, Toolkit.swt_newt);
+        SWTChartComponentFactory f = new SWTChartComponentFactory(parent);
+        return f.newChart(Quality.Intermediate, Toolkit.swt_newt);
     }
-    
+
     public static Chart chart(Composite parent, Quality quality) {
-    	SWTChartComponentFactory f = new SWTChartComponentFactory(parent);
-    	return f.newChart(quality, Toolkit.swt_newt);
+        SWTChartComponentFactory f = new SWTChartComponentFactory(parent);
+        return f.newChart(quality, Toolkit.swt_newt);
     }
 
     /* */
@@ -65,9 +65,9 @@ public class SWTChartComponentFactory extends ChartComponentFactory {
     public Chart newChart(IChartComponentFactory factory, Quality quality, String toolkit) {
         return new SWTChart(canvas, factory, quality, toolkit);
     }
-    
+
     public Composite getComposite() {
-    	return canvas;
+        return canvas;
     }
 
     @Override
@@ -126,7 +126,7 @@ public class SWTChartComponentFactory extends ChartComponentFactory {
             Dimension dimension = getCanvasDimension(windowingToolkit);
             return new OffscreenCanvas(factory, scene, quality, capabilities, dimension.width, dimension.height, traceGL, debugGL);
         case swt_newt:
-        	return new CanvasNewtSWT(factory, scene, quality, capabilities, traceGL, debugGL);
+            return new CanvasNewtSWT(factory, scene, quality, capabilities, traceGL, debugGL);
         default:
             throw new RuntimeException("unknown chart type:" + chartType);
         }
@@ -151,12 +151,12 @@ public class SWTChartComponentFactory extends ChartComponentFactory {
 
     @Override
     public ICameraMouseController newMouseCameraController(Chart chart) {
-            return new NewtCameraMouseController(chart);
+        return new NewtCameraMouseController(chart);
     }
-    
+
     @Override
     public IMousePickingController newMousePickingController(Chart chart, int clickWidth) {
-            return new NewtMousePickingController(chart, clickWidth);
+        return new NewtMousePickingController(chart, clickWidth);
     }
 
     /**
@@ -167,8 +167,7 @@ public class SWTChartComponentFactory extends ChartComponentFactory {
         // trigger screenshot on 's' letter
         String file = SCREENSHOT_FOLDER + "capture-" + Utils.dat2str(new Date(), "yyyy-MM-dd-HH-mm-ss") + ".png";
         IScreenshotKeyController screenshot = new NewtScreenshotKeyController(chart, file);
-        
-        
+
         screenshot.addListener(new IScreenshotEventListener() {
             @Override
             public void failedScreenshot(String file, Exception e) {

--- a/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChartComponentFactory.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/chart/swt/SWTChartComponentFactory.java
@@ -38,9 +38,9 @@ import org.jzy3d.plot3d.rendering.view.layout.IViewportLayout;
 import com.jogamp.opengl.GLCapabilities;
 
 public class SWTChartComponentFactory extends ChartComponentFactory {
-    static Logger logger = Logger.getLogger(SWTChartComponentFactory.class);
+    private static final Logger logger = Logger.getLogger(SWTChartComponentFactory.class);
 
-    private Composite canvas;
+    private final Composite canvas;
 
     private SWTChartComponentFactory(Composite canvas) {
         this.canvas = canvas;
@@ -128,7 +128,7 @@ public class SWTChartComponentFactory extends ChartComponentFactory {
         case swt_newt:
             return new CanvasNewtSWT(factory, scene, quality, capabilities, traceGL, debugGL);
         default:
-            throw new RuntimeException("unknown chart type:" + chartType);
+            throw new IllegalArgumentException("unknown chart type:" + chartType);
         }
     }
 
@@ -184,8 +184,7 @@ public class SWTChartComponentFactory extends ChartComponentFactory {
 
     @Override
     public ICameraKeyController newKeyboardCameraController(Chart chart) {
-        ICameraKeyController key = new NewtCameraKeyController(chart);
-        return key;
+        return new NewtCameraKeyController(chart);
     }
 
     @Override

--- a/jzy3d-swt/src/main/java/org/jzy3d/plot2d/rendering/CanvasSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/plot2d/rendering/CanvasSWT.java
@@ -1,136 +1,128 @@
 package org.jzy3d.plot2d.rendering;
 
-
-
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.widgets.Display;
 import org.jzy3d.colors.Color;
 
-
-
-
 // TODO: handling of color disposing is an enormous mess!
 
-public class CanvasSWT implements Canvas{
-	/**
+public class CanvasSWT implements Canvas {
+    /**
      * Creates a new instance of Pencil2dAWT.
-     * 
      * A Pencil2dAWT provides an implementation for drawing wafer sites
      * on an SWT GC (Graphic Context).
      */
-	public CanvasSWT(GC graphic){
-		target = graphic;
-	}
-	
-	public void dispose(){
-		if(bgColor!=null)
-			bgColor.dispose();
-		if(fgColor!=null)
-			fgColor.dispose();
-	}
-	
-	@Override
-    public void drawString( int x, int y, String text ){
-		target.setBackground(bgColor);
-		target.setForeground(fgColor); //display.getSystemColor(SWT.COLOR_BLUE)
-		target.setFont( new Font( Display.getDefault(), "Arial", 8, SWT.NONE ) ); //SWT.BOLD
-		target.drawString(text, x, y);
-	}
-	
-	@Override
-    public void drawRect( Color color, int x, int y, int width, int height, boolean border ){
-		if(color!=null){
-			if(current!=null)
-				current.dispose();
-			current = swt(color);
-			
-			target.setBackground(current);
-			target.fillRectangle(x, y, width, height);
-		}
-		
-		if(border){
-			target.setForeground(fgColor);
-			target.drawRectangle(x, y, width, height);
-		}
-		
-		bgColor.dispose();
-	}
-	
-	@Override
-    public void drawRect( Color color, int x, int y, int width, int height ){
-		drawRect( color, x, y, width, height, true );
-	}
-	
-	@Override
-    public void drawDot( Color color, int x, int y ){
-		if(current!=null)
-			current.dispose();
-		current = swt(color);
-		
-		target.setBackground(current);
-		target.setForeground(current);
-		target.drawRectangle(x-PIXEL_WITH/2, y-PIXEL_WITH/2, PIXEL_WITH, PIXEL_WITH);
-		//target.drawRectangle(x, y, PIXEL_WITH, PIXEL_WITH);
-	}
-	
-	@Override
-    public void drawOval( Color color, int x, int y, int width, int height ){
-		if(current!=null)
-			current.dispose();
-		current = swt(color);
-		
-		target.setBackground(current);
-		target.fillOval(x, y, width, height);
-		target.setForeground(BLACK);
-		target.drawOval(x, y, width, height);
-	}
+    public CanvasSWT(GC graphic) {
+        target = graphic;
+    }
 
-	@Override
-    public void drawBackground( Color color, int width, int heigth ){
-		if(bgColor!=null)
-			bgColor.dispose();
-		bgColor = swt(color);
-		
-		target.setBackground(bgColor);
-		target.setForeground(fgColor);
-		target.fillRectangle(0, 0, width, heigth);	
-	}
-	
-	/**********************************************************************************/
+    public void dispose() {
+        if (bgColor != null)
+            bgColor.dispose();
+        if (fgColor != null)
+            fgColor.dispose();
+    }
 
-	/** Converts a {@link org.jzy3d.colors.Color Imaging Color} 
-	 * into a {@link org.eclipse.swt.graphics.Color SWT Color}.
-	 *
-	 * Note that SWT colors do not have an alpha channel.
-	 */
-	public static org.eclipse.swt.graphics.Color swt(Color color){
-		return new org.eclipse.swt.graphics.Color(Display.getDefault(),(int)(255*color.r),(int)(255*color.g),(int)(255*color.b));
-	}
-	
-	/**********************************************************************************/
+    @Override
+    public void drawString(int x, int y, String text) {
+        target.setBackground(bgColor);
+        target.setForeground(fgColor); // display.getSystemColor(SWT.COLOR_BLUE)
+        target.setFont(new Font(Display.getDefault(), "Arial", 8, SWT.NONE)); // SWT.BOLD
+        target.drawString(text, x, y);
+    }
 
-	/** Set up an initial reference to the SWT Display.*/
-	/*static{
-		d = Display.getDefault();
-	}
-	
-	private static Display d;*/
-	
-	/**********************************************************************************/
+    @Override
+    public void drawRect(Color color, int x, int y, int width, int height, boolean border) {
+        if (color != null) {
+            if (current != null)
+                current.dispose();
+            current = swt(color);
 
-	private GC target;
-	private org.eclipse.swt.graphics.Color bgColor = new org.eclipse.swt.graphics.Color(Display.getDefault(), 255, 255, 255 ); // default bg
-	private org.eclipse.swt.graphics.Color fgColor = new org.eclipse.swt.graphics.Color(Display.getDefault(), 0, 0, 0 ); // default bg
-	private org.eclipse.swt.graphics.Color current; 
-	
-	@SuppressWarnings("unused")  
-	private static org.eclipse.swt.graphics.Color WHITE = 
-		new org.eclipse.swt.graphics.Color(Display.getDefault(), 255, 255, 255 );
-	private static org.eclipse.swt.graphics.Color BLACK = 
-		new org.eclipse.swt.graphics.Color(Display.getDefault(), 0, 0, 0 );
-	
-	private final static int PIXEL_WITH = 1; 
+            target.setBackground(current);
+            target.fillRectangle(x, y, width, height);
+        }
+
+        if (border) {
+            target.setForeground(fgColor);
+            target.drawRectangle(x, y, width, height);
+        }
+
+        bgColor.dispose();
+    }
+
+    @Override
+    public void drawRect(Color color, int x, int y, int width, int height) {
+        drawRect(color, x, y, width, height, true);
+    }
+
+    @Override
+    public void drawDot(Color color, int x, int y) {
+        if (current != null)
+            current.dispose();
+        current = swt(color);
+
+        target.setBackground(current);
+        target.setForeground(current);
+        target.drawRectangle(x - PIXEL_WITH / 2, y - PIXEL_WITH / 2, PIXEL_WITH, PIXEL_WITH);
+        // target.drawRectangle(x, y, PIXEL_WITH, PIXEL_WITH);
+    }
+
+    @Override
+    public void drawOval(Color color, int x, int y, int width, int height) {
+        if (current != null)
+            current.dispose();
+        current = swt(color);
+
+        target.setBackground(current);
+        target.fillOval(x, y, width, height);
+        target.setForeground(BLACK);
+        target.drawOval(x, y, width, height);
+    }
+
+    @Override
+    public void drawBackground(Color color, int width, int heigth) {
+        if (bgColor != null)
+            bgColor.dispose();
+        bgColor = swt(color);
+
+        target.setBackground(bgColor);
+        target.setForeground(fgColor);
+        target.fillRectangle(0, 0, width, heigth);
+    }
+
+    /**********************************************************************************/
+
+    /**
+     * Converts a {@link org.jzy3d.colors.Color Imaging Color}
+     * into a {@link org.eclipse.swt.graphics.Color SWT Color}.
+     * Note that SWT colors do not have an alpha channel.
+     */
+    public static org.eclipse.swt.graphics.Color swt(Color color) {
+        return new org.eclipse.swt.graphics.Color(Display.getDefault(), (int) (255 * color.r), (int) (255 * color.g), (int) (255 * color.b));
+    }
+
+    /**********************************************************************************/
+
+    /** Set up an initial reference to the SWT Display. */
+    /*
+     * static{
+     * d = Display.getDefault();
+     * }
+     * private static Display d;
+     */
+
+    /**********************************************************************************/
+
+    private GC target;
+    private org.eclipse.swt.graphics.Color bgColor = new org.eclipse.swt.graphics.Color(Display.getDefault(), 255, 255, 255); // default bg
+    private org.eclipse.swt.graphics.Color fgColor = new org.eclipse.swt.graphics.Color(Display.getDefault(), 0, 0, 0); // default bg
+    private org.eclipse.swt.graphics.Color current;
+
+    @SuppressWarnings("unused")
+    private static org.eclipse.swt.graphics.Color WHITE = new org.eclipse.swt.graphics.Color(Display.getDefault(), 255, 255, 255);
+    private static org.eclipse.swt.graphics.Color BLACK = new org.eclipse.swt.graphics.Color(Display.getDefault(), 0, 0, 0);
+
+    private final static int PIXEL_WITH = 1;
 }

--- a/jzy3d-swt/src/main/java/org/jzy3d/plot2d/rendering/CanvasSWT.java
+++ b/jzy3d-swt/src/main/java/org/jzy3d/plot2d/rendering/CanvasSWT.java
@@ -19,10 +19,12 @@ public class CanvasSWT implements Canvas {
     }
 
     public void dispose() {
-        if (bgColor != null)
+        if (bgColor != null) {
             bgColor.dispose();
-        if (fgColor != null)
+        }
+        if (fgColor != null) {
             fgColor.dispose();
+        }
     }
 
     @Override
@@ -36,8 +38,9 @@ public class CanvasSWT implements Canvas {
     @Override
     public void drawRect(Color color, int x, int y, int width, int height, boolean border) {
         if (color != null) {
-            if (current != null)
+            if (current != null) {
                 current.dispose();
+            }
             current = swt(color);
 
             target.setBackground(current);
@@ -59,20 +62,21 @@ public class CanvasSWT implements Canvas {
 
     @Override
     public void drawDot(Color color, int x, int y) {
-        if (current != null)
+        if (current != null) {
             current.dispose();
+        }
         current = swt(color);
 
         target.setBackground(current);
         target.setForeground(current);
         target.drawRectangle(x - PIXEL_WITH / 2, y - PIXEL_WITH / 2, PIXEL_WITH, PIXEL_WITH);
-        // target.drawRectangle(x, y, PIXEL_WITH, PIXEL_WITH);
     }
 
     @Override
     public void drawOval(Color color, int x, int y, int width, int height) {
-        if (current != null)
+        if (current != null) {
             current.dispose();
+        }
         current = swt(color);
 
         target.setBackground(current);
@@ -83,8 +87,9 @@ public class CanvasSWT implements Canvas {
 
     @Override
     public void drawBackground(Color color, int width, int heigth) {
-        if (bgColor != null)
+        if (bgColor != null) {
             bgColor.dispose();
+        }
         bgColor = swt(color);
 
         target.setBackground(bgColor);
@@ -105,24 +110,14 @@ public class CanvasSWT implements Canvas {
 
     /**********************************************************************************/
 
-    /** Set up an initial reference to the SWT Display. */
-    /*
-     * static{
-     * d = Display.getDefault();
-     * }
-     * private static Display d;
-     */
-
-    /**********************************************************************************/
-
-    private GC target;
+    private final GC target;
     private org.eclipse.swt.graphics.Color bgColor = new org.eclipse.swt.graphics.Color(Display.getDefault(), 255, 255, 255); // default bg
-    private org.eclipse.swt.graphics.Color fgColor = new org.eclipse.swt.graphics.Color(Display.getDefault(), 0, 0, 0); // default bg
+    private final org.eclipse.swt.graphics.Color fgColor = new org.eclipse.swt.graphics.Color(Display.getDefault(), 0, 0, 0); // default bg
     private org.eclipse.swt.graphics.Color current;
 
     @SuppressWarnings("unused")
-    private static org.eclipse.swt.graphics.Color WHITE = new org.eclipse.swt.graphics.Color(Display.getDefault(), 255, 255, 255);
-    private static org.eclipse.swt.graphics.Color BLACK = new org.eclipse.swt.graphics.Color(Display.getDefault(), 0, 0, 0);
+    private static final org.eclipse.swt.graphics.Color WHITE = new org.eclipse.swt.graphics.Color(Display.getDefault(), 255, 255, 255);
+    private static final org.eclipse.swt.graphics.Color BLACK = new org.eclipse.swt.graphics.Color(Display.getDefault(), 0, 0, 0);
 
-    private final static int PIXEL_WITH = 1;
+    private static final int PIXEL_WITH = 1;
 }


### PR DESCRIPTION
If a Chart is disposed and as a follow up `CanvasSWT.dispose()` was called the canvas remained in its parent as a white or black canvas because `super.dispose()` was not called so the SWT-disposal process was not initiated.

Amendment:
Additionally I did some code formatting in the SWT-project since the code was formatted inconsistently itself and to the rest of jzy3d and some clean up and avoids of code duplications.
Furthermore I use the JFace ResourceManager in `CanvasSWT` to handle `Color` and `Font` resources in order to solved the `TODO` annotation, complaining about the SWT-resource handling.

As a result of the discussion I moved the jzy3D resource release into the disposeListener of `CanvasSWT` and removed dispose. Now if dispose is called for a `CanvasSWT` instance `Widget.dispose()` is called directly and within the disposal process the jzy3d-resources are released by the dispose-listener. So the initial issue of this PR is resolved with that and release of jzy3d-resources is still ensured.