### PR TITLE
Fix Camera.side() calculation and improve Camera

### DIFF
--- a/jzy3d-core-awt/src/main/java/org/jzy3d/plot3d/rendering/view/AWTView.java
+++ b/jzy3d-core-awt/src/main/java/org/jzy3d/plot3d/rendering/view/AWTView.java
@@ -3,7 +3,6 @@ package org.jzy3d.plot3d.rendering.view;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.jzy3d.chart.ChartView;
 import org.jzy3d.chart.factories.IChartFactory;
 import org.jzy3d.colors.Color;
@@ -31,6 +30,7 @@ public class AWTView extends ChartView {
     super(factory, scene, canvas, quality);
   }
 
+  @Override
   public void initInstance(IChartFactory factory, Scene scene, ICanvas canvas, Quality quality) {
     super.initInstance(factory, scene, canvas, quality);
     this.backgroundViewport = new AWTImageViewport();
@@ -92,8 +92,7 @@ public class AWTView extends ChartView {
 
     Coord3d target = newBounds.getCenter();
     Coord3d eye = viewpoint.cartesian().add(target);
-    cam.setTarget(target);
-    cam.setEye(eye);
+    cam.setPosition(eye, target);
   }
 
   @Override


### PR DESCRIPTION
With this PR I want to submit a fix for the camera side calculation. The scale of the data was not considered and the side calculation itself was (for me) not completely comprehensible. I think there was the assumption that the up-direction is always (0,0,1).

My point about the side calculation can be seen easily with the `org.jzy3d.demos.scatter.ScatterDemo` if you use the following `init()` method with that fixed points:
>     public void init() {
> 
>         Coord3d[] points = new Coord3d[8];
> 
>         points[0] = new Coord3d(7.0404835, 905.0, 53.014378);
>         points[1] = new Coord3d(7.0043426, 935.0, 53.014378);
>         points[2] = new Coord3d(7.0404835, 905.0, 53.014378);
>         points[3] = new Coord3d(6.9886136, 885.0, 151.9809);
>         points[4] = new Coord3d(7.0043426, 935.0, 53.014378);
>         points[5] = new Coord3d(6.96367, 915.0, 153.10077);
>         points[6] = new Coord3d(6.9886136, 885.0, 151.9809);
>         points[7] = new Coord3d(6.96367, 915.0, 153.10077);
> 
>         Scatter scatter = new Scatter(points, Color.BLUE, 5.0f);
>         chart = AWTChartComponentFactory.chart(Quality.Advanced, "newt");
>         chart.getScene().add(scatter);
>     }
> 
The z-axis label should be at the right side, but jumps from right to left and back when you rotate the diagram (mainly around the z-axis).

To fix this issue I added a `scale` field to `Camera` and additionally improved the structure how the camera position is set (all parameters are set together with `setPosition()`) and made the old methods deprecated (If you want to keep them, I can remove the deprecation). Additionally I improved the structure of the calling methods in Axis and split `computeCameraUpAndTriggerEvents()` in two methods, without changing the behaviour.


In the second commit I add three flags to `AxeBox` to control if axis-labels and -ticks are drawn at the bottom or top respectively left or right. I personally like the z-labels and -ticks on the left. With that commit the user can choose his preference for that. The default is the previous behaviour (labels/ticks at the bottom respectively right). 
If you like it, I can make this part of the `IAxe` interface or maybe better of the `IAxeLayout` interface.