### PR TITLE
Use HTTPS URLs

### DIFF
--- a/jzy3d-core/data/objfiles/bunny.url
+++ b/jzy3d-core/data/objfiles/bunny.url
@@ -1,1 +1,1 @@
-http://download.jzy3d.org/objfiles/bunny.obj
+https://download.jzy3d.org/objfiles/bunny.obj

--- a/jzy3d-core/data/objfiles/dragon.url
+++ b/jzy3d-core/data/objfiles/dragon.url
@@ -1,1 +1,1 @@
-http://download.jzy3d.org/objfiles/dragon.obj
+https://download.jzy3d.org/objfiles/dragon.obj

--- a/jzy3d-core/src/main/java/org/jzy3d/maths/Coord2d.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/maths/Coord2d.java
@@ -214,7 +214,7 @@ public class Coord2d implements Serializable {
 
   /**
    * Return a real polar value, with an angle in the range [0;2*PI]
-   * http://fr.wikipedia.org/wiki/Coordonn%C3%A9es_polaires
+   * https://en.wikipedia.org/wiki/Polar_coordinate_system
    */
   public Coord2d fullPolar() {
     double radius = Math.sqrt(x * x + y * y);

--- a/jzy3d-core/src/main/java/org/jzy3d/maths/algorithms/interpolation/algorithms/Spline3D.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/maths/algorithms/interpolation/algorithms/Spline3D.java
@@ -9,7 +9,7 @@ import org.jzy3d.maths.Coord3d;
  * <p>
  * This is a generic 3D B-Spline class for curves of arbitrary length, control handles and patches
  * are created and joined automatically as described here:
- * <a href="http://www.ibiblio.org/e-notes/Splines/Bint.htm">ibiblio.org/e-notes/
+ * <a href="https://www.ibiblio.org/e-notes/Splines/Bint.htm">ibiblio.org/e-notes/
  * Splines/Bint.htm</a>
  * </p>
  * 

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/LineStrip.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/LineStrip.java
@@ -25,7 +25,7 @@ import org.jzy3d.plot3d.transform.space.SpaceTransformer;
  * 
  * Dotted line are built using
  * 
- * http://www.glprogramming.com/red/images/Image35.gif
+ * https://www.glprogramming.com/red/images/Image35.gif
  * 
  * @author Martin Pernollet
  */
@@ -316,7 +316,7 @@ public class LineStrip extends Wireframeable {
   /**
    * Indicates if stippled rendering is enabled for this line.
    * 
-   * @see http://www.glprogramming.com/red/chapter02.html (Stippled line section)
+   * @see https://www.glprogramming.com/red/chapter02.html (Stippled line section)
    */
   public boolean isStipple() {
     return stipple;
@@ -325,7 +325,7 @@ public class LineStrip extends Wireframeable {
   /**
    * Enable or disable stippled rendering.
    * 
-   * @see http://www.glprogramming.com/red/chapter02.html (Stippled line section)
+   * @see https://www.glprogramming.com/red/chapter02.html (Stippled line section)
    */
   public void setStipple(boolean stipple) {
     this.stipple = stipple;
@@ -334,8 +334,8 @@ public class LineStrip extends Wireframeable {
   /**
    * Stippled line factor.
    * 
-   * @see http://www.glprogramming.com/red/images/Image35.gif
-   * @see http://www.glprogramming.com/red/chapter02.html (Stippled line section)
+   * @see https://www.glprogramming.com/red/images/Image35.gif
+   * @see https://www.glprogramming.com/red/chapter02.html (Stippled line section)
    */
   public int getStippleFactor() {
     return stippleFactor;
@@ -344,8 +344,8 @@ public class LineStrip extends Wireframeable {
   /**
    * Stippled line factor.
    * 
-   * @see http://www.glprogramming.com/red/images/Image35.gif
-   * @see http://www.glprogramming.com/red/chapter02.html (Stippled line section)
+   * @see https://www.glprogramming.com/red/images/Image35.gif
+   * @see https://www.glprogramming.com/red/chapter02.html (Stippled line section)
    */
   public void setStippleFactor(int stippleFactor) {
     this.stippleFactor = stippleFactor;
@@ -354,8 +354,8 @@ public class LineStrip extends Wireframeable {
   /**
    * Stippled line pattern.
    * 
-   * @see http://www.glprogramming.com/red/images/Image35.gif
-   * @see http://www.glprogramming.com/red/chapter02.html (Stippled line section)
+   * @see https://www.glprogramming.com/red/images/Image35.gif
+   * @see https://www.glprogramming.com/red/chapter02.html (Stippled line section)
    */
   public short getStipplePattern() {
     return stipplePattern;
@@ -364,8 +364,8 @@ public class LineStrip extends Wireframeable {
   /**
    * Stippled line pattern.
    * 
-   * @see http://www.glprogramming.com/red/images/Image35.gif
-   * @see http://www.glprogramming.com/red/chapter02.html (Stippled line section)
+   * @see https://www.glprogramming.com/red/images/Image35.gif
+   * @see https://www.glprogramming.com/red/chapter02.html (Stippled line section)
    */
   public void setStipplePattern(short stipplePattern) {
     this.stipplePattern = stipplePattern;

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/rendering/lights/LightSet.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/rendering/lights/LightSet.java
@@ -34,7 +34,7 @@ public class LightSet {
     }
   }
   
-  // http://www.sjbaker.org/steve/omniv/opengl_lighting.html
+  // https://www.sjbaker.org/steve/omniv/opengl_lighting.html
   protected void initLight(IPainter painter) {
     painter.glEnable_ColorMaterial();
     painter.glEnable_Lighting();

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/rendering/view/ViewportConfiguration.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/rendering/view/ViewportConfiguration.java
@@ -7,7 +7,7 @@ import org.jzy3d.plot3d.rendering.canvas.ICanvas;
  * 
  * It is define by a width and height, and support an X and Y offset
  * 
- * @see http://www.opengl.org/sdk/docs/man/xhtml/glViewport.xml
+ * @see https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glViewport.xhtml
  * @author Martin Pernollet
  */
 public class ViewportConfiguration {

--- a/jzy3d-depthpeeling/src/api/org/jzy3d/plot3d/rendering/shaders/Shaderable.java
+++ b/jzy3d-depthpeeling/src/api/org/jzy3d/plot3d/rendering/shaders/Shaderable.java
@@ -34,7 +34,7 @@ public class Shaderable implements IShaderable {
 
   /* PROGRAM */
 
-  // http://www.opengl.org/wiki/GLSL_:_common_mistakes
+  // https://www.khronos.org/opengl/wiki/GLSL_:_common_mistakes
   protected void loadProgram(GL2 gl) {
     program = new GLSLProgram();
     program.loadAndCompileVertexShader(gl, shaders.getVertexURL());

--- a/jzy3d-io-xls/src/main/java/org/jzy3d/io/xls/ExcelBuilder.java
+++ b/jzy3d-io-xls/src/main/java/org/jzy3d/io/xls/ExcelBuilder.java
@@ -47,8 +47,8 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
  *
  * To add new excel features, see
  *
- * @see http://poi.apache.org/spreadsheet/quick-guide.html (or a copy in /doc)
- * @see http://svn.apache.org/repos/asf/poi/trunk/src/examples/src/org/apache/poi/xssf/usermodel/examples/
+ * @see https://poi.apache.org/components/spreadsheet/quick-guide.html (or a copy in /doc)
+ * @see https://svn.apache.org/repos/asf/poi/trunk/poi-examples/src/main/java/org/apache/poi/examples/xssf/usermodel/
  */
 public class ExcelBuilder implements IExcelBuilder {
   static Log log = LogFactory.getLog(ExcelBuilder.class);

--- a/jzy3d-jGL/README.md
+++ b/jzy3d-jGL/README.md
@@ -1,21 +1,21 @@
 # jGL
 
-A pure Java implementation of OpenGL, still [online](http://graphics.im.ntu.edu.tw/~robin/jGL/) with [example gallery](http://graphics.im.ntu.edu.tw/~robin/jGL/Example/index.html) and an [LGPL licence](http://www.gnu.org/licenses/lgpl-3.0.html)
+A pure Java implementation of OpenGL, still [online](https://www.cmlab.csie.ntu.edu.tw/~robin/jGL/) with [example gallery](https://www.cmlab.csie.ntu.edu.tw/~robin/jGL/Example/index.html) and an [LGPL licence](https://www.gnu.org/licenses/lgpl-3.0.html)
 
 
 # History
 
-[jGL](http://www.cmlab.csie.ntu.edu.tw/~robin/jGL/) was created by Robin Bing-Yu Chen in 1996 and has been maintained up to 2006. 
+[jGL](https://www.cmlab.csie.ntu.edu.tw/~robin/jGL/) was created by Robin Bing-Yu Chen in 1996 and has been maintained up to 2006. 
 It is a pure java implementation of OpenGL 1, hence performing 3d rendering with CPU instead of GPU. 
 Some papers about jGL published by Robin have been added to the `doc/papers` folder which clarify all his work.
-It comes with [lot of OpenGL Red Book examples](http://www.cmlab.csie.ntu.edu.tw/~robin/jGL/Example-app/index.html) proving how well
+It comes with [lot of OpenGL Red Book examples](https://www.cmlab.csie.ntu.edu.tw/~robin/jGL/Example-app/index.html) proving how well
 this OpenGL implementation works. The examples are released as [AWT applications](https://github.com/jzy3d/jGL/tree/master/src/main/java/examples/apps)
 and [Applets](https://github.com/jzy3d/jGL/tree/master/src/main/java/examples/applets).
 
 
 In 2020, CPU are much more faster than in 2006 and experiments have showned that one can get very decent rendering 
 performance for simple 3D scenes showing surface or scatter point charts. Despite not exhaustive at all, I was able 
-to have the following performance on a MacBook Pro (Retina 15 pouces, début 2013), 2,7 GHz Intel Core i7, RAM 16 Go 1600 MHz DDR3
+to have the following performance on a MacBook Pro (Retina 15 pouces, début 2013), 2,7 GHz Intel Core i7, RAM 16 Go 1600 MHz DDR3
 - A 60x60 polygon 3D surface in a 500x500 pixels frame is rendered in ~30ms. 
 - A 60x60 polygon 3D surface in a 1440x800 pixel frame is rendered in ~45ms
 - A 50.000 points 3D scatter in a 500x500 pixels frame is rendered in ~10ms.
@@ -103,12 +103,12 @@ Maven artifacts are stored there (you should add this to your pom file root):
     <repository>
         <id>jzy3d-snapshots</id>
         <name>Jzy3d Snapshots</name>
-        <url>http://maven.jzy3d.org/snapshots/</url>
+        <url>https://maven.jzy3d.org/snapshots/</url>
     </repository>
     <repository>
         <id>jzy3d-releases</id>
         <name>Jzy3d Releases</name>
-        <url>http://maven.jzy3d.org/releases/</url>
+        <url>https://maven.jzy3d.org/releases/</url>
     </repository>
 </repositories>
 ```

--- a/jzy3d-jGL/README.md
+++ b/jzy3d-jGL/README.md
@@ -85,7 +85,7 @@ rendering at all until the Paint event
 
 You should add this to your pom file dependencies node, using the latest Jzy3d version:
 
-```
+```xml
 <dependency>
     <groupId>org.jzy3d</groupId>
     <artifactId>jGL</artifactId>
@@ -98,7 +98,7 @@ Note that the repository was formerly standalone and versioned following Robin v
 
 Maven artifacts are stored there (you should add this to your pom file root):
 
-```
+```xml
 <repositories>
     <repository>
         <id>jzy3d-snapshots</id>
@@ -195,18 +195,17 @@ GL.glFlush()
 
 
 # Javadoc and UML documentation
-Javadoc with UML generated with [yFiles Doclet tool](https://www.yworks.com/downloads#yDoc).
-Configuration file in doc/yfiles.uml.options.jgl.linux
-Run ```javadoc @/Users/martin/Dev/jzy3d/public/jGL/doc/uml/yfiles.uml.options.jgl.linux```
+Javadoc with UML generated with [yFiles Doclet tool](https://www.yworks.com/downloads#yDoc).  
+Configuration file in `doc/yfiles.uml.options.jgl.linux`  
+Run `javadoc @/Users/martin/Dev/jzy3d/public/jGL/doc/uml/yfiles.uml.options.jgl.linux`
 
 
  
 # Features
 
-|Name          |Tested |Integrated in Jzy3D|Version| 
-----------------------------------------------------
-|Alpha blending|Yes    |Yes                |2.5    | 
+|Name          |Tested |Integrated in Jzy3D|Version|
+| ------------ | ----- | ----------------- | ----- |
+|Alpha blending|Yes    |Yes                |2.5    |
 |Text          |Yes    |Yes                |2.5    |
-|Lightning     |No     |No                 |2.4    | 
- 
+|Lightning     |No     |No                 |2.4    |
 

--- a/jzy3d-native-jogl-awt/README.md
+++ b/jzy3d-native-jogl-awt/README.md
@@ -21,7 +21,7 @@ Build files
 
 Library dependencies
 --------------
-- <a href="http://jogamp.org/jogl/www/">jogl2</a>
+- <a href="https://jogamp.org/jogl/www/">jogl2</a>
 - <a href="https://github.com/jzy3d/jzy3d-api/tree/master/jzy3d-jdt-core">jdt</a> (Java Delaunay Triangulation)
 - opencsv
 - log4j

--- a/jzy3d-native-jogl-awt/data/objfiles/bunny.url
+++ b/jzy3d-native-jogl-awt/data/objfiles/bunny.url
@@ -1,1 +1,1 @@
-http://download.jzy3d.org/objfiles/bunny.obj
+https://download.jzy3d.org/objfiles/bunny.obj

--- a/jzy3d-native-jogl-awt/data/objfiles/dragon.url
+++ b/jzy3d-native-jogl-awt/data/objfiles/dragon.url
@@ -1,1 +1,1 @@
-http://download.jzy3d.org/objfiles/dragon.obj
+https://download.jzy3d.org/objfiles/dragon.obj

--- a/jzy3d-native-jogl-core/src/main/java/org/jzy3d/painters/GLES2CompatUtils.java
+++ b/jzy3d-native-jogl-core/src/main/java/org/jzy3d/painters/GLES2CompatUtils.java
@@ -230,14 +230,14 @@ public class GLES2CompatUtils {
   public static void glVertex3d(double d, float f, float g) {
     throw new UnsupportedOperationException();
     // FIXME ANDROID OPEN7 GL ES
-    // cf http://pandorawiki.org/Porting_to_GLES_from_GL
+    // cf https://pandorawiki.org/Porting_to_GLES_from_GL
   }
 
   public static void glLineStipple(int i, short s) {
     throw new UnsupportedOperationException();
     // FIXME ANDROID OPEN GL ES
     // cf
-    // http://stackoverflow.com/questions/1806028/how-to-draw-a-dotted-line-using-opengl-es-1
+    // https://stackoverflow.com/questions/1806028/how-to-draw-a-dotted-line-using-opengl-es-1
 
   }
 

--- a/jzy3d-native-jogl-core/src/main/java/org/jzy3d/plot3d/primitives/vbo/drawable/DrawableVBO2.java
+++ b/jzy3d-native-jogl-core/src/main/java/org/jzy3d/plot3d/primitives/vbo/drawable/DrawableVBO2.java
@@ -693,7 +693,7 @@ public class DrawableVBO2 extends Wireframeable implements IGLBindedResource {
    * 
    * @param painter holds a GL instance to invoke the GPU.
    * 
-   * @see http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-9-vbo-indexing/
+   * @see https://www.opengl-tutorial.org/intermediate-tutorials/tutorial-9-vbo-indexing/
    * @see https://github.com/opengl-tutorials/ogl/blob/master/tutorial09_vbo_indexing/tutorial09.cpp
    */
   protected void doDrawElements(IPainter painter) {

--- a/jzy3d-native-jogl-core/src/main/java/org/jzy3d/plot3d/primitives/vbo/drawable/SphereVBO.java
+++ b/jzy3d-native-jogl-core/src/main/java/org/jzy3d/plot3d/primitives/vbo/drawable/SphereVBO.java
@@ -24,7 +24,7 @@ import com.jogamp.opengl.util.GLBuffers;
  * 
  * This is true when Quality.setAlphaActivated(false), in other word for Quality.Advanced.
  * 
- * @uthor David Eck inspired this class with http://math.hws.edu/graphicsbook/source/jogl/ColorCubeOfSpheres.java
+ * @uthor David Eck inspired this class with https://math.hws.edu/graphicsbook/source/jogl/ColorCubeOfSpheres.java
  * @author Martin Pernollet
  */
 public class SphereVBO extends DrawableVBO {
@@ -85,7 +85,7 @@ public class SphereVBO extends DrawableVBO {
 
   // element array buffer is an index:
   // @see
-  // http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-9-vbo-indexing/
+  // https://www.opengl-tutorial.org/intermediate-tutorials/tutorial-9-vbo-indexing/
   @Override
   public void draw(IPainter painter) {
     if (hasMountedOnce) {

--- a/jzy3d-native-jogl-javafx/README.md
+++ b/jzy3d-native-jogl-javafx/README.md
@@ -21,7 +21,7 @@ Build files
 
 Library dependencies
 --------------
-- <a href="http://jogamp.org/jogl/www/">jogl2</a>
+- <a href="https://jogamp.org/jogl/www/">jogl2</a>
 - <a href="https://github.com/jzy3d/jzy3d-api/tree/master/jzy3d-jdt-core">jdt</a> (Java Delaunay Triangulation)
 - opencsv
 - log4j

--- a/jzy3d-native-jogl-javafx/src/main/java/org/jzy3d/javafx/controllers/mouse/JavaFXCameraThreadController.java
+++ b/jzy3d-native-jogl-javafx/src/main/java/org/jzy3d/javafx/controllers/mouse/JavaFXCameraThreadController.java
@@ -6,7 +6,7 @@ import javafx.application.Platform;
 
 /**
  * Trying to get rid of an exception
- * http://stackoverflow.com/questions/860187/access-restriction-on-class-due-to-restriction-on-required-library-rt-jar
+ * https://stackoverflow.com/questions/860187/access-restriction-on-class-due-to-restriction-on-required-library-rt-jar
  * 
  * @author Martin Pernollet
  *

--- a/jzy3d-native-jogl-newt/README.md
+++ b/jzy3d-native-jogl-newt/README.md
@@ -21,7 +21,7 @@ Build files
 
 Library dependencies
 --------------
-- <a href="http://jogamp.org/jogl/www/">jogl2</a>
+- <a href="https://jogamp.org/jogl/www/">jogl2</a>
 - <a href="https://github.com/jzy3d/jzy3d-api/tree/master/jzy3d-jdt-core">jdt</a> (Java Delaunay Triangulation)
 - opencsv
 - log4j

--- a/jzy3d-native-jogl-swing/README.md
+++ b/jzy3d-native-jogl-swing/README.md
@@ -21,7 +21,7 @@ Build files
 
 Library dependencies
 --------------
-- <a href="http://jogamp.org/jogl/www/">jogl2</a>
+- <a href="https://jogamp.org/jogl/www/">jogl2</a>
 - <a href="https://github.com/jzy3d/jzy3d-api/tree/master/jzy3d-jdt-core">jdt</a> (Java Delaunay Triangulation)
 - opencsv
 - log4j

--- a/jzy3d-native-jogl-swt/README.md
+++ b/jzy3d-native-jogl-swt/README.md
@@ -21,7 +21,7 @@ Build files
 
 Library dependencies
 --------------
-- <a href="http://jogamp.org/jogl/www/">jogl2</a>
+- <a href="https://jogamp.org/jogl/www/">jogl2</a>
 - <a href="https://github.com/jzy3d/jzy3d-api/tree/master/jzy3d-jdt-core">jdt</a> (Java Delaunay Triangulation)
 - opencsv
 - log4j

--- a/jzy3d-native-jogl-swt/src/main/java/org/jzy3d/bridge/swt/SWT_AWT_Bridge.java
+++ b/jzy3d-native-jogl-swt/src/main/java/org/jzy3d/bridge/swt/SWT_AWT_Bridge.java
@@ -41,7 +41,7 @@ import org.eclipse.swt.widgets.Composite;
  * </code><br>
  * <br>
  * If problems are encountered with the Bridge, it is possible to check:<br>
- * http://wiki.eclipse.org/Albireo_SWT_AWT_bugs<br>
+ * https://wiki.eclipse.org/Albireo_SWT_AWT_bugs<br>
  * http://www.eclipsezone.com/eclipse/forums/t45697.html<br>
  *
  * @author Martin Pernollet

--- a/jzy3d-svm-mapper/doc/datasources.txt
+++ b/jzy3d-svm-mapper/doc/datasources.txt
@@ -1,2 +1,2 @@
-http://archive.ics.uci.edu/ml/
+https://archive.ics.uci.edu/ml/
 kaviar: http://trac.clermont.cemagref.fr/projets/Kaviar/wiki

--- a/jzy3d-tools-libsvm/README.md
+++ b/jzy3d-tools-libsvm/README.md
@@ -1,7 +1,7 @@
 jzy3d-tools-libsvm
 ===================
 
-A clone of http://www.csie.ntu.edu.tw/~cjlin/libsvm/
+A clone of https://www.csie.ntu.edu.tw/~cjlin/libsvm/
 
 Contains:
 - few refactors of libsvm to more easily access internal state of the vector machine.

--- a/jzy3d-tools-libsvm/doc/datasources.txt
+++ b/jzy3d-tools-libsvm/doc/datasources.txt
@@ -1,2 +1,2 @@
-http://archive.ics.uci.edu/ml/
+https://archive.ics.uci.edu/ml/
 kaviar: http://trac.clermont.cemagref.fr/projets/Kaviar/wiki

--- a/jzy3d-tutorials/README.md
+++ b/jzy3d-tutorials/README.md
@@ -19,12 +19,12 @@ See [pom.xml](pom.xml) file as an example.
   <repository>
     <id>jzy3d-snapshots</id>
     <name>Jzy3d Snapshots</name>
-    <url>http://maven.jzy3d.org/snapshots/</url>
+    <url>https://maven.jzy3d.org/snapshots/</url>
   </repository>
   <repository>
     <id>jzy3d-releases</id>
     <name>Jzy3d Releases</name>
-    <url>http://maven.jzy3d.org/releases/</url>
+    <url>https://maven.jzy3d.org/releases/</url>
   </repository>
 </repositories>
 ```

--- a/jzy3d-tutorials/src/main/java/org/jzy3d/demos/volume/LizardVolumeDemo.java
+++ b/jzy3d-tutorials/src/main/java/org/jzy3d/demos/volume/LizardVolumeDemo.java
@@ -15,7 +15,7 @@ import com.jmatio.types.MLNumericArray;
 import com.jogamp.opengl.util.GLBuffers;
 
 /**
- * Get lizard file from http://download.jzy3d.org/objfiles/lizard.mat
+ * Get lizard file from https://download.jzy3d.org/objfiles/lizard.mat
  * 
  * @author Jacok Filik
  *

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<licenses>
 		<license>
 			<name>The (New) BSD License</name>
-			<url>http://www.opensource.org/licenses/bsd-license.php</url>
+			<url>https://opensource.org/licenses/bsd-license.php</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
@@ -25,7 +25,7 @@
 			<id>martin.pernollet</id>
 			<name>Martin Pernollet</name>
 			<email>martin@jzy3d.org</email>
-			<url>http://twitter.com/jzy3d</url>
+			<url>https://twitter.com/jzy3d</url>
 		</developer>
 		<developer>
 			<id>nils.hoffmann</id>


### PR DESCRIPTION
Replaces HTTP URLs in documentation and code with HTTPS URLs in case the target supports it.
There are also a few dead links; in some cases I tried to replace them with (what I assume) is the now correct link. Could you please check whether they are correct?