### PR TITLE
Workaround a Swing bug related to 2D view updates

### DIFF
--- a/jzy3d-core/src/main/java/org/jzy3d/chart/Chart.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/chart/Chart.java
@@ -199,7 +199,7 @@ public class Chart {
 
       // Hack for swing : https://github.com/jzy3d/jzy3d-api/issues/293
       if(getPainter().getWindowingToolkit().isSwing()) {
-        render();
+        render(2);
       }
     }
     return this;
@@ -245,7 +245,7 @@ public class Chart {
       
       // Hack for swing : https://github.com/jzy3d/jzy3d-api/issues/293
       if(getPainter().getWindowingToolkit().isSwing()) {
-        render();
+        render(2);
       }
     }
 

--- a/jzy3d-core/src/main/java/org/jzy3d/chart/Chart.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/chart/Chart.java
@@ -196,6 +196,11 @@ public class Chart {
     // Update if needed
     if (!getQuality().isAnimated()) {
       render();
+
+      // Hack for swing : https://github.com/jzy3d/jzy3d-api/issues/293
+      if(getPainter().getWindowingToolkit().isSwing()) {
+        render();
+      }
     }
     return this;
   }
@@ -237,6 +242,11 @@ public class Chart {
     // Update if needed
     if (!getQuality().isAnimated()) {
       render();
+      
+      // Hack for swing : https://github.com/jzy3d/jzy3d-api/issues/293
+      if(getPainter().getWindowingToolkit().isSwing()) {
+        render();
+      }
     }
 
     return this;

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/SampleGeom.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/SampleGeom.java
@@ -33,10 +33,10 @@ public class SampleGeom {
 
     Shape surface =
         new SurfaceBuilder().orthonormal(new OrthonormalGrid(xRange, steps, yRange, steps), mapper);
-    ColorMapper colorMapper = new ColorMapper(new ColorMapRainbow(), surface.getBounds().getZmin(),
-        surface.getBounds().getZmax(), new Color(1, 1, 1, alpha));
-    surface.setColorMapper(colorMapper);
     
+    ColorMapper colorMapper = new ColorMapper(new ColorMapRainbow(), surface, new Color(1, 1, 1, alpha));
+
+    surface.setColorMapper(colorMapper);
     surface.setFaceDisplayed(true);
     surface.setWireframeDisplayed(true);
     surface.setWireframeColor(Color.BLACK);

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/rendering/canvas/Quality.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/rendering/canvas/Quality.java
@@ -257,6 +257,7 @@ public class Quality {
         smoothPolygon, disableDepthTestWhenAlpha);
     copy.isAnimated = isAnimated;
     copy.isAutoSwapBuffer = isAutoSwapBuffer;
+    copy.preserveViewportSize = preserveViewportSize;
     return copy;
   }
 

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/rendering/view/View.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/rendering/view/View.java
@@ -70,7 +70,7 @@ public class View {
   protected CameraMode cameraMode;
   protected ViewPositionMode viewMode;
   protected ViewBoundMode boundsMode;
-  protected Color backgroundColor = Color.BLACK;
+  protected Color backgroundColor = Color.WHITE.clone();
   protected boolean axisDisplayed = true;
   protected boolean squared = true;
 
@@ -682,8 +682,13 @@ public class View {
 
   /** Clear the color and depth buffer. */
   public void clear() {
+    //System.err.println("View.Clear : " + backgroundColor);
+    //System.err.println("View.clear : " + Color.WHITE + " for white");
+    
     painter.clearColor(backgroundColor);
     painter.glClearDepth(1);
+    
+    
 
     // Console.println("View.clear with color", backgroundColor);
 

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/rendering/view/View.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/rendering/view/View.java
@@ -70,7 +70,7 @@ public class View {
   protected CameraMode cameraMode;
   protected ViewPositionMode viewMode;
   protected ViewBoundMode boundsMode;
-  protected Color backgroundColor = Color.WHITE.clone();
+  protected Color backgroundColor = Color./*BLACK;*/WHITE.clone();
   protected boolean axisDisplayed = true;
   protected boolean squared = true;
 

--- a/jzy3d-emul-gl-awt/src/main/java/org/jzy3d/painters/EmulGLPainter.java
+++ b/jzy3d-emul-gl-awt/src/main/java/org/jzy3d/painters/EmulGLPainter.java
@@ -15,6 +15,7 @@ import org.jzy3d.colors.Color;
 import org.jzy3d.maths.Array;
 import org.jzy3d.maths.Coord2d;
 import org.jzy3d.maths.Coord3d;
+import org.jzy3d.os.WindowingToolkit;
 import org.jzy3d.plot3d.pipelines.NotImplementedException;
 import org.jzy3d.plot3d.primitives.PolygonFill;
 import org.jzy3d.plot3d.primitives.PolygonMode;
@@ -39,6 +40,16 @@ public class EmulGLPainter extends AbstractPainter implements IPainter {
   /** A 1x1 image used for processing text length in pixel if no context is available */
   protected BufferedImage textLengthFallbackImage;
   protected FontMetrics fontMetricsFallback;
+  
+  @Override
+  public WindowingToolkit getWindowingToolkit() {
+    String name = getCanvas().getClass().getSimpleName();
+
+    if (name.indexOf("EmulGLCanvas") >= 0) {
+      return WindowingToolkit.AWT;
+    } 
+    return WindowingToolkit.UNKOWN;
+  }
 
 
   public GL getGL() {

--- a/jzy3d-emul-gl-awt/src/test/java/org/jzy3d/painters/TestEmulGLPainterFactory.java
+++ b/jzy3d-emul-gl-awt/src/test/java/org/jzy3d/painters/TestEmulGLPainterFactory.java
@@ -1,5 +1,6 @@
 package org.jzy3d.painters;
 
+import static org.mockito.Mockito.mock;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -13,10 +14,12 @@ import org.jzy3d.chart.factories.IChartFactory;
 import org.jzy3d.chart.factories.IPainterFactory;
 import org.jzy3d.junit.ChartTester;
 import org.jzy3d.maths.Range;
+import org.jzy3d.os.WindowingToolkit;
 import org.jzy3d.plot3d.builder.Mapper;
 import org.jzy3d.plot3d.builder.SurfaceBuilder;
 import org.jzy3d.plot3d.builder.concrete.OrthonormalGrid;
 import org.jzy3d.plot3d.primitives.Shape;
+import org.jzy3d.plot3d.rendering.canvas.EmulGLCanvas;
 
 public class TestEmulGLPainterFactory {
   @Test
@@ -66,5 +69,15 @@ public class TestEmulGLPainterFactory {
     Shape surface = builder.orthonormal(new OrthonormalGrid(range, steps), mapper);
     surface.setFaceDisplayed(true);
     return surface;
+  }
+  
+  @Test
+  public void detectAWT() {
+    IPainterFactory p = new EmulGLPainterFactory();
+    IPainter painter = p.newPainter();
+    
+    painter.setCanvas(mock(EmulGLCanvas.class));
+    
+    Assert.assertEquals(WindowingToolkit.AWT, painter.getWindowingToolkit());
   }
 }

--- a/jzy3d-native-jogl-core/src/main/java/org/jzy3d/chart/factories/NativePainterFactory.java
+++ b/jzy3d-native-jogl-core/src/main/java/org/jzy3d/chart/factories/NativePainterFactory.java
@@ -151,10 +151,12 @@ public abstract class NativePainterFactory implements IPainterFactory {
     GLCapabilities caps = new GLCapabilities(glp);
     caps.setHardwareAccelerated(true);
 
-    // false lead to not erased background on MacOS X 10.15.3 (Catalina) but not 10.12
+    // false lead to not erased background on MacOS 10.15.3 (Catalina) 
+    // but not on MacOS 10.12
     caps.setDoubleBuffered(true);
 
     boolean fixedResolution = true;
+    
     if (fixedResolution) {
       caps.setAlphaBits(8);
       caps.setRedBits(8);


### PR DESCRIPTION
Render twice when changing 3D to 2D view in case of Swing canvas.