### PR TITLE
Feature/configure up axis

### DIFF
--- a/jzy3d-core-awt/src/main/java/org/jzy3d/chart/controllers/mouse/camera/AWTCameraMouseController.java
+++ b/jzy3d-core-awt/src/main/java/org/jzy3d/chart/controllers/mouse/camera/AWTCameraMouseController.java
@@ -71,6 +71,7 @@ public class AWTCameraMouseController extends AbstractCameraController
   @Override
   public void register(Chart chart) {
     super.register(chart);
+    
     chart.getCanvas().addMouseController(this);
 
     configureScaler(chart);
@@ -103,6 +104,8 @@ public class AWTCameraMouseController extends AbstractCameraController
 
   public void unregister(Chart chart) {
     super.unregister(chart);
+    
+    chart.getCanvas().removeMouseController(this);
 
     if (chart.getView() instanceof AWTView) {
       ((AWTView) chart.getView()).removeRenderer2d(moveRenderer);

--- a/jzy3d-core/src/main/java/org/jzy3d/maths/BoundingBox3d.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/maths/BoundingBox3d.java
@@ -74,6 +74,10 @@ public class BoundingBox3d {
     this.zmax = zmax;
   }
 
+  public BoundingBox3d(double xmin, double xmax, double ymin, double ymax, double zmin, double zmax) {
+    this((float)xmin, (float)xmax, (float)ymin, (float)ymax, (float)zmin, (float)zmax);
+  }
+  
   public BoundingBox3d(Range xRange, Range yRange, Range zRange) {
     this.xmin = xRange.getMin();
     this.xmax = xRange.getMax();

--- a/jzy3d-core/src/main/java/org/jzy3d/maths/Coord3d.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/maths/Coord3d.java
@@ -168,6 +168,10 @@ public class Coord3d implements Serializable {
     return new Coord3d(this.x + x, this.y + y, this.z + z);
   }
 
+  public Coord3d add(double x, double y, double z) {
+    return add((float)x, (float)y, (float)z);
+  }
+  
   public Coord3d addSelf(Coord3d c2) {
     x += c2.x;
     y += c2.y;

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/Drawable.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/Drawable.java
@@ -89,7 +89,7 @@ public abstract class Drawable implements IGLRenderer, ISortableDraw {
   protected void doDrawBoundsIfDisplayed(IPainter painter) {
     if (isBoundingBoxDisplayed()) {
       int width = 2; // getWireframeWidth()
-      painter.box(bbox, getBoundingBoxColor(), 2, spaceTransformer);
+      painter.box(bbox, getBoundingBoxColor(), width, spaceTransformer);
     }
   }
 

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/axis/AxisBase.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/axis/AxisBase.java
@@ -1,8 +1,11 @@
 package org.jzy3d.plot3d.primitives.axis;
 
 import java.util.List;
+import org.jzy3d.colors.Color;
 import org.jzy3d.maths.BoundingBox3d;
+import org.jzy3d.maths.Coord2d;
 import org.jzy3d.maths.Coord3d;
+import org.jzy3d.painters.Font;
 import org.jzy3d.painters.IPainter;
 import org.jzy3d.plot3d.primitives.axis.annotations.AxeAnnotation;
 import org.jzy3d.plot3d.primitives.axis.layout.AxisLayout;
@@ -65,7 +68,7 @@ public class AxisBase implements IAxis {
   public void draw(IPainter painter) {
     painter.glLoadIdentity();
     painter.glScalef(scale.x, scale.y, scale.z);
-    painter.glLineWidth(2);
+    painter.glLineWidth(1);
 
 
     float x = 0, y = 0, z = 0;
@@ -104,12 +107,52 @@ public class AxisBase implements IAxis {
     Horizontal h = Horizontal.CENTER;
     Vertical v = Vertical.CENTER;
 
-    textRenderer.drawText(painter, layout.getFont(), layout.getXAxisLabel(), xLabel, h, v,
-        layout.getXTickColor());
-    textRenderer.drawText(painter, layout.getFont(), layout.getYAxisLabel(), yLabel, h, v,
-        layout.getYTickColor());
-    textRenderer.drawText(painter, layout.getFont(), layout.getZAxisLabel(), zLabel, h, v,
-        layout.getZTickColor());
+    Font f = layout.getFont();
+
+    Color xcolor = layout.getXTickColor();
+    Color ycolor = layout.getYTickColor();
+    Color zcolor = layout.getZTickColor();
+
+    if (layout.isXAxisLabelDisplayed())
+      textRenderer.drawText(painter, f, layout.getXAxisLabel(), xLabel, h, v, xcolor);
+
+    if (layout.isYAxisLabelDisplayed())
+      textRenderer.drawText(painter, f, layout.getYAxisLabel(), yLabel, h, v, ycolor);
+
+    if (layout.isZAxisLabelDisplayed())
+      textRenderer.drawText(painter, f, layout.getZAxisLabel(), zLabel, h, v, zcolor);
+
+    
+    if (layout.isXTickLabelDisplayed()) {
+      String xmax = layout.getXTickRenderer().format(boundingBox.getXmax());
+      xLabel = new Coord3d(boundingBox.getXmax(), y, z);
+      
+      Coord2d offset = new Coord2d(-5, 0);
+
+      textRenderer.drawText(painter, f, xmax, xLabel, Horizontal.LEFT, v, xcolor, offset);
+
+    }
+
+    if (layout.isYTickLabelDisplayed()) {
+      String ymax = layout.getYTickRenderer().format(boundingBox.getYmax());
+      yLabel = new Coord3d(x, boundingBox.getYmax(), z);
+      
+      Coord2d offset = new Coord2d(-5, 0);
+
+      textRenderer.drawText(painter, f, ymax, yLabel, Horizontal.LEFT, v, ycolor, offset);
+
+    }
+
+    if (layout.isZTickLabelDisplayed()) {
+      String zmax = layout.getZTickRenderer().format(boundingBox.getZmax());
+      zLabel = new Coord3d(x, y, boundingBox.getZmax());
+      
+      Coord2d offset = new Coord2d(0, -5);
+
+      textRenderer.drawText(painter, f, zmax, zLabel, Horizontal.LEFT, v, ycolor, offset);
+
+    }
+
   }
 
   /**

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/axis/AxisBase.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/axis/AxisBase.java
@@ -7,6 +7,8 @@ import org.jzy3d.painters.IPainter;
 import org.jzy3d.plot3d.primitives.axis.annotations.AxeAnnotation;
 import org.jzy3d.plot3d.primitives.axis.layout.AxisLayout;
 import org.jzy3d.plot3d.text.ITextRenderer;
+import org.jzy3d.plot3d.text.align.Horizontal;
+import org.jzy3d.plot3d.text.align.Vertical;
 import org.jzy3d.plot3d.text.renderers.TextRenderer;
 import org.jzy3d.plot3d.transform.space.SpaceTransformer;
 
@@ -23,17 +25,30 @@ public class AxisBase implements IAxis {
 
   protected ITextRenderer textRenderer = new TextRenderer();
 
+  protected float exceedFactor = 0.1f;
+  protected float textShiftFactor = 0.1f;
+
+  enum AxePassThrough {
+    ZERO, MIN;
+  }
+
+  protected AxePassThrough passThrough = AxePassThrough.ZERO;
+
 
   /** Create a simple axe centered on (0,0,0), with a dimension of 1. */
   public AxisBase() {
-    setAxe(new BoundingBox3d(0, 1, 0, 1, 0, 1));
-    setScale(new Coord3d(1.0f, 1.0f, 1.0f));
+    this(new BoundingBox3d(0, 1, 0, 1, 0, 1));
   }
 
   /** Create a simple axe centered on (box.xmin, box.ymin, box.zmin) */
   public AxisBase(BoundingBox3d box) {
+    this(box, new AxisLayout());
+  }
+
+  public AxisBase(BoundingBox3d box, AxisLayout layout) {
     setAxe(box);
     setScale(new Coord3d(1.0f, 1.0f, 1.0f));
+    this.layout = layout;
   }
 
   @Override
@@ -52,17 +67,49 @@ public class AxisBase implements IAxis {
     painter.glScalef(scale.x, scale.y, scale.z);
     painter.glLineWidth(2);
 
+
+    float x = 0, y = 0, z = 0;
+    if (AxePassThrough.MIN.equals(passThrough)) {
+      x = boundingBox.getXmin();
+      y = boundingBox.getYmin();
+      z = boundingBox.getZmin();
+    }
+
+    float xExceed = exceedFactor * boundingBox.getRange().x;
+    float yExceed = exceedFactor * boundingBox.getRange().y;
+    float zExceed = exceedFactor * boundingBox.getRange().z;
+
     painter.glBegin_Line();
-    painter.glColor3f(1.0f, 0.0f, 0.0f); // R
-    painter.glVertex3f(boundingBox.getXmin(), boundingBox.getYmin(), boundingBox.getZmin());
-    painter.glVertex3f(boundingBox.getXmax(), 0, 0);
-    painter.glColor3f(0.0f, 1.0f, 0.0f); // G
-    painter.glVertex3f(boundingBox.getXmin(), boundingBox.getYmin(), boundingBox.getZmin());
-    painter.glVertex3f(0, boundingBox.getYmax(), 0);
-    painter.glColor3f(0.0f, 0.0f, 1.0f); // B
-    painter.glVertex3f(boundingBox.getXmin(), boundingBox.getYmin(), boundingBox.getZmin());
-    painter.glVertex3f(0, 0, boundingBox.getZmax());
+
+    // X AXIS
+    painter.color(layout.getGridColor());
+    painter.glVertex3f(boundingBox.getXmin() - xExceed, y, z);
+    painter.glVertex3f(boundingBox.getXmax() + xExceed, y, z);
+
+    // painter.color(Color.GREEN);
+    painter.glVertex3f(x, boundingBox.getYmin() - yExceed, z);
+    painter.glVertex3f(x, boundingBox.getYmax() + yExceed, z);
+
+    // painter.color(Color.BLUE);
+    painter.glVertex3f(x, y, boundingBox.getZmin() - zExceed);
+    painter.glVertex3f(x, y, boundingBox.getZmax() + zExceed);
     painter.glEnd();
+
+
+    // Label
+    Coord3d xLabel = new Coord3d(boundingBox.getXmax() + xExceed * 2, y, z);
+    Coord3d yLabel = new Coord3d(x, boundingBox.getYmax() + yExceed * 2, z);
+    Coord3d zLabel = new Coord3d(x, y, boundingBox.getZmax() + zExceed * 2);
+
+    Horizontal h = Horizontal.CENTER;
+    Vertical v = Vertical.CENTER;
+
+    textRenderer.drawText(painter, layout.getFont(), layout.getXAxisLabel(), xLabel, h, v,
+        layout.getXTickColor());
+    textRenderer.drawText(painter, layout.getFont(), layout.getYAxisLabel(), yLabel, h, v,
+        layout.getYTickColor());
+    textRenderer.drawText(painter, layout.getFont(), layout.getZAxisLabel(), zLabel, h, v,
+        layout.getZTickColor());
   }
 
   /**

--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/axis/layout/renderers/TrigonometricTickRenderer.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/primitives/axis/layout/renderers/TrigonometricTickRenderer.java
@@ -60,9 +60,14 @@ public class TrigonometricTickRenderer implements ITickRenderer {
       if (eq(value, PI)) {
         return π;
       }
-      // 2*π
-      else if (eq(value, PI_MUL_2)) {
-        return "2" + π;
+      // 2*π or above integer multiple of π
+      else if (value >= PI_MUL_2){
+        int nPi = (int)Math.round(value / PI);
+        double remainder = value-(nPi*PI);
+        double remainderAbs = Math.abs(remainder);
+        if(remainderAbs<delta) {
+          return nPi + π;
+        }
       }
       // fraction
       else {
@@ -92,10 +97,17 @@ public class TrigonometricTickRenderer implements ITickRenderer {
       if (eq(value, -PI)) {
         return "-" + π;
       }
-      // -2π
-      else if (eq(value, -PI_MUL_2)) {
-        return "-2" + π;
+      // -2π or above integer multiple of π
+      else if (value <= -PI_MUL_2){
+        int nPi = (int)Math.round(value / PI);
+        double remainder = value-(nPi*PI);
+        double remainderAbs = Math.abs(remainder);
+        if(remainderAbs<delta) {
+          return nPi + π;
+        }
       }
+
+      
       // fraction
       else {
         for (int i = 2; i <= maxDenominator; i++) {

--- a/jzy3d-core/src/test/java/org/jzy3d/plot3d/primitives/axis/layout/renderers/TestTrigonometricTickRenderer.java
+++ b/jzy3d-core/src/test/java/org/jzy3d/plot3d/primitives/axis/layout/renderers/TestTrigonometricTickRenderer.java
@@ -5,12 +5,23 @@ import org.junit.Test;
 
 public class TestTrigonometricTickRenderer {
   @Test
+  public void test2() {
+    TrigonometricTickRenderer r = new TrigonometricTickRenderer();
+    Assert.assertEquals("3π/2", r.format(Math.PI*3/2));
+    Assert.assertEquals("10π", r.format(Math.PI*10));
+
+  }
+  
+  @Test
   public void test() {
     TrigonometricTickRenderer r = new TrigonometricTickRenderer();
 
     Assert.assertEquals("0", r.format(0));
 
     Assert.assertEquals("2π", r.format(Math.PI*2));
+    Assert.assertEquals("3π", r.format(Math.PI*3));
+    Assert.assertEquals("4π", r.format(Math.PI*4));
+
     
     Assert.assertEquals("π", r.format(Math.PI));
     Assert.assertEquals("π/2", r.format(Math.PI/2));
@@ -19,6 +30,8 @@ public class TestTrigonometricTickRenderer {
     Assert.assertEquals("π/5", r.format(Math.PI/5));
     Assert.assertEquals("π/6", r.format(Math.PI/6));
     
+    Assert.assertEquals("-4π", r.format(-Math.PI*4));
+    Assert.assertEquals("-3π", r.format(-Math.PI*3));
     Assert.assertEquals("-2π", r.format(-Math.PI*2));
     Assert.assertEquals("-π", r.format(-Math.PI));
     Assert.assertEquals("-π/2", r.format(-Math.PI/2));

--- a/jzy3d-core/src/test/java/org/jzy3d/plot3d/rendering/view/TestView.java
+++ b/jzy3d-core/src/test/java/org/jzy3d/plot3d/rendering/view/TestView.java
@@ -5,6 +5,9 @@ import static org.mockito.Mockito.when;
 import org.junit.Assert;
 import org.junit.Test;
 import org.jzy3d.maths.BoundingBox3d;
+import org.jzy3d.maths.Coord2d;
+import org.jzy3d.maths.Coord3d;
+import org.jzy3d.plot3d.primitives.axis.Axis;
 import org.jzy3d.plot3d.primitives.axis.AxisBox;
 import org.jzy3d.plot3d.rendering.scene.Graph;
 import org.jzy3d.plot3d.rendering.scene.Scene;
@@ -51,5 +54,59 @@ public class TestView {
     Assert.assertEquals(boundsManual, view.getBounds());
 
   }
+  
+  @Test
+  public void whenUpVectorChange_ThenViewpointRotationChange() {
+    double H_SHIFT = Math.PI/6;
+    double V_SHIFT = Math.PI/4;
+    
+    View view = new View();
+    view.scene = mock(Scene.class);
+    view.cam = mock(Camera.class);
+    view.axis = mock(AxisBox.class); 
+
+    // ---------------------------------------
+    // Given a default view with Z up vector
+    Coord3d viewpoint = new Coord3d(0, 0, 10);
+    view.setViewPoint(viewpoint);
+
+    // When
+    view.rotate(new Coord2d(H_SHIFT, V_SHIFT));
+    
+    // Then
+    Coord3d expectViewpoint = new Coord3d(-H_SHIFT, V_SHIFT, 10);
+    Assert.assertEquals(expectViewpoint, view.getViewPoint());
+    Assert.assertEquals(View.UP_VECTOR_Z, view.getUpVector());
+    
+    // ---------------------------------------
+    // Given a default view with X up vector
+    viewpoint = new Coord3d(0, 0, 10);
+    view.setViewPoint(viewpoint);
+    view.setUpVector(Axis.X);
+    
+    // When
+    view.rotate(new Coord2d(H_SHIFT, V_SHIFT));
+    
+    // Then
+    expectViewpoint = new Coord3d(V_SHIFT, H_SHIFT, 10);
+    Assert.assertEquals(expectViewpoint, view.getViewPoint());
+    Assert.assertEquals(View.UP_VECTOR_X, view.getUpVector());
+    
+    // ---------------------------------------
+    // Given a default view with Y up vector
+    viewpoint = new Coord3d(0, 0, 10);
+    view.setViewPoint(viewpoint);
+    view.setUpVector(Axis.Y);
+    
+    // When
+    view.rotate(new Coord2d(-H_SHIFT, -V_SHIFT));
+    
+    // Then
+    expectViewpoint = new Coord3d(V_SHIFT, H_SHIFT, 10);
+    Assert.assertEquals(expectViewpoint, view.getViewPoint());
+    Assert.assertEquals(View.UP_VECTOR_Y, view.getUpVector());
+
+  }
+
 
 }


### PR DESCRIPTION
Deployed the 29th september 2022 as `2.2.1-SNAPSHOT`

Allow to configure the view with a camera with "head" toward another axis than Z.

Also
- Unregister the AWT mouse controller from the canvas to avoid exceptions after calling controller.unregister(chart)
- Let trigonometric tick renderer handle positive or negative integer multiples of PI
- rework `AxisBase` to allow using a more standard representation of an axis (a line for each X, Y, Z dimension)