### PR TITLE
Add null check

### DIFF
--- a/jzy3d-core/src/main/java/org/jzy3d/plot3d/text/renderers/TextRenderer.java
+++ b/jzy3d-core/src/main/java/org/jzy3d/plot3d/text/renderers/TextRenderer.java
@@ -85,6 +85,11 @@ public class TextRenderer extends AbstractTextRenderer implements ITextRenderer 
     if (spaceTransformer != null) {
       positionAligned = spaceTransformer.compute(positionAligned);
     }
+
+    if (positionAligned == null) {
+        return null;
+    }
+
     positionAligned = positionAligned.add(sceneOffset);
 
     // Draws actual string


### PR DESCRIPTION
This prevents a crash when rotating a 3d diagram continuously "for a long time" according to @aw-imgsys.